### PR TITLE
feat: cfd-455 fix table styling on long entries on other products table

### DIFF
--- a/repos/fdbt-site/src/pages/products/otherProducts.tsx
+++ b/repos/fdbt-site/src/pages/products/otherProducts.tsx
@@ -73,11 +73,15 @@ const otherProductsTable = (otherProducts: MyFaresOtherFaresProduct[]): ReactEle
                     {otherProducts.length > 0
                         ? otherProducts.map((product, index) => (
                               <tr className="govuk-table__row" key={`product-${index}`}>
-                                  <td className="govuk-table__cell">{product.productDescription}</td>
+                                  <td className="govuk-table__cell dft-table-wrap-anywhere dft-table-fixed-width">
+                                      {product.productDescription}
+                                  </td>
                                   <td className="govuk-table__cell">{sentenceCaseString(product.type)}</td>
                                   <td className="govuk-table__cell">{product.duration}</td>
                                   <td className="govuk-table__cell">{product.quantity}</td>
-                                  <td className="govuk-table__cell">{sentenceCaseString(product.passengerType)}</td>
+                                  <td className="govuk-table__cell dft-table-wrap-anywhere dft-table-fixed-width">
+                                      {sentenceCaseString(product.passengerType)}
+                                  </td>
                                   <td className="govuk-table__cell">{product.startDate}</td>
                                   <td className="govuk-table__cell">{product.endDate}</td>
                                   <td className="govuk-table__cell">{getTag(product.startDate, product.endDate)}</td>

--- a/repos/fdbt-site/tests/pages/products/__snapshots__/otherProducts.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/products/__snapshots__/otherProducts.test.tsx.snap
@@ -203,7 +203,7 @@ exports[`myfares pages otherProducts should render correctly when some non-Point
               key="product-0"
             >
               <td
-                className="govuk-table__cell"
+                className="govuk-table__cell dft-table-wrap-anywhere dft-table-fixed-width"
               >
                 First product
               </td>
@@ -223,7 +223,7 @@ exports[`myfares pages otherProducts should render correctly when some non-Point
                 1
               </td>
               <td
-                className="govuk-table__cell"
+                className="govuk-table__cell dft-table-wrap-anywhere dft-table-fixed-width"
               >
                 Infant
               </td>
@@ -252,7 +252,7 @@ exports[`myfares pages otherProducts should render correctly when some non-Point
               key="product-1"
             >
               <td
-                className="govuk-table__cell"
+                className="govuk-table__cell dft-table-wrap-anywhere dft-table-fixed-width"
               >
                 The greatest product eveer!
               </td>
@@ -272,7 +272,7 @@ exports[`myfares pages otherProducts should render correctly when some non-Point
                 20
               </td>
               <td
-                className="govuk-table__cell"
+                className="govuk-table__cell dft-table-wrap-anywhere dft-table-fixed-width"
               >
                 Infant
               </td>
@@ -301,7 +301,7 @@ exports[`myfares pages otherProducts should render correctly when some non-Point
               key="product-2"
             >
               <td
-                className="govuk-table__cell"
+                className="govuk-table__cell dft-table-wrap-anywhere dft-table-fixed-width"
               >
                 The greatest product eveer!
               </td>
@@ -321,7 +321,7 @@ exports[`myfares pages otherProducts should render correctly when some non-Point
                 1
               </td>
               <td
-                className="govuk-table__cell"
+                className="govuk-table__cell dft-table-wrap-anywhere dft-table-fixed-width"
               >
                 Adult
               </td>


### PR DESCRIPTION
# Description

-   Fix table styling issues on the otherProducts page.

# Testing instructions

-   Add a long name for products that go into the otherProducts page and you should see a table that fits within the page boundaries.

# Type of change

-   [x] feat - A new feature
-   [ ] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy
