### PR TITLE
fix: Removed hard coded bods value

### DIFF
--- a/repos/fdbt-site/src/pages/direction.tsx
+++ b/repos/fdbt-site/src/pages/direction.tsx
@@ -1,6 +1,11 @@
 import React, { ReactElement } from 'react';
 import TwoThirdsLayout from '../layout/Layout';
-import { SERVICE_ATTRIBUTE, DIRECTION_ATTRIBUTE, FARE_TYPE_ATTRIBUTE } from '../constants/attributes';
+import {
+    SERVICE_ATTRIBUTE,
+    DIRECTION_ATTRIBUTE,
+    FARE_TYPE_ATTRIBUTE,
+    TXC_SOURCE_ATTRIBUTE,
+} from '../constants/attributes';
 import { getServiceByIdAndDataSource } from '../data/auroradb';
 import { ErrorInfo, NextPageContextWithSession } from '../interfaces';
 import ErrorSummary from '../components/ErrorSummary';
@@ -73,14 +78,14 @@ export const getServerSideProps = async (
 
     const directionAttribute = getSessionAttribute(ctx.req, DIRECTION_ATTRIBUTE);
     const nocCode = getAndValidateNoc(ctx);
-
+    const dataSourceAttribute = getSessionAttribute(ctx.req, TXC_SOURCE_ATTRIBUTE);
     const serviceAttribute = getSessionAttribute(ctx.req, SERVICE_ATTRIBUTE);
 
-    if (!isService(serviceAttribute) || !nocCode || !ctx.res) {
+    if (!isService(serviceAttribute) || !nocCode || !ctx.res || !dataSourceAttribute) {
         throw new Error('Necessary attributes not found to show direction page');
     }
 
-    const service = await getServiceByIdAndDataSource(nocCode, serviceAttribute.id, 'bods');
+    const service = await getServiceByIdAndDataSource(nocCode, serviceAttribute.id, dataSourceAttribute.source);
     const directions = Array.from(
         service.journeyPatterns.reduce((set, pattern) => {
             set.add(pattern.direction);

--- a/repos/fdbt-site/tests/pages/direction.test.tsx
+++ b/repos/fdbt-site/tests/pages/direction.test.tsx
@@ -31,10 +31,16 @@ describe('pages', () => {
         });
 
         describe('getServerSideProps', () => {
-            it('returns correct values fpr props', async () => {
+            it('returns correct values for props', async () => {
                 (({ ...getServiceByIdAndDataSource } as jest.Mock).mockImplementation(() => mockRawService));
 
-                const ctx = getMockContext();
+                const ctx = getMockContext({
+                    body: { serviceId: '123' },
+                    uuid: {},
+                    session: {
+                        [TXC_SOURCE_ATTRIBUTE]: { source: 'tnds', hasTnds: true, hasBods: true },
+                    },
+                });
 
                 const result = await getServerSideProps(ctx);
 


### PR DESCRIPTION
# Description

-   The direction page was hard coded to getting bods data, even when the txc_data_source_attribute was set to TNDS. This meant that it would only ever go get BODS directions, or fail for TNDS.

# Testing instructions

-   Ensure direction page works for TNDS services.

# Type of change

-   [ ] feat - A new feature
-   [x] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy
