### PR TITLE
DBODS-1113: Vulnerability bumps

### DIFF
--- a/repos/fdbt-netex-output/package-lock.json
+++ b/repos/fdbt-netex-output/package-lock.json
@@ -84,613 +84,758 @@
                 "node": ">=6.0.0"
             }
         },
-        "node_modules/@aws-crypto/crc32": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
-            "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "@aws-crypto/util": "^3.0.0",
-                "@aws-sdk/types": "^3.222.0",
-                "tslib": "^1.11.1"
-            }
-        },
-        "node_modules/@aws-crypto/crc32/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "dev": true,
-            "peer": true
-        },
-        "node_modules/@aws-crypto/ie11-detection": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
-            "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "tslib": "^1.11.1"
-            }
-        },
-        "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "dev": true,
-            "peer": true
-        },
         "node_modules/@aws-crypto/sha256-browser": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
-            "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+            "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@aws-crypto/ie11-detection": "^3.0.0",
-                "@aws-crypto/sha256-js": "^3.0.0",
-                "@aws-crypto/supports-web-crypto": "^3.0.0",
-                "@aws-crypto/util": "^3.0.0",
+                "@aws-crypto/sha256-js": "^5.2.0",
+                "@aws-crypto/supports-web-crypto": "^5.2.0",
+                "@aws-crypto/util": "^5.2.0",
                 "@aws-sdk/types": "^3.222.0",
                 "@aws-sdk/util-locate-window": "^3.0.0",
-                "@aws-sdk/util-utf8-browser": "^3.0.0",
-                "tslib": "^1.11.1"
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
             }
         },
-        "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+        "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+            "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
             "dev": true,
-            "peer": true
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+            "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/is-array-buffer": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
         },
         "node_modules/@aws-crypto/sha256-js": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
-            "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+            "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@aws-crypto/util": "^3.0.0",
+                "@aws-crypto/util": "^5.2.0",
                 "@aws-sdk/types": "^3.222.0",
-                "tslib": "^1.11.1"
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
             }
-        },
-        "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "dev": true,
-            "peer": true
         },
         "node_modules/@aws-crypto/supports-web-crypto": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
-            "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+            "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "tslib": "^1.11.1"
+                "tslib": "^2.6.2"
             }
         },
-        "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "dev": true,
-            "peer": true
-        },
         "node_modules/@aws-crypto/util": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
-            "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+            "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "^3.222.0",
-                "@aws-sdk/util-utf8-browser": "^3.0.0",
-                "tslib": "^1.11.1"
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
             }
         },
-        "node_modules/@aws-crypto/util/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+        "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+            "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
             "dev": true,
-            "peer": true
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+            "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/is-array-buffer": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
         },
         "node_modules/@aws-sdk/client-cloudformation": {
-            "version": "3.414.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.414.0.tgz",
-            "integrity": "sha512-ONyE0pjC2irMGqI80WcX7I9OgIYjyLQQnR7Z0s1kZ2K/fX/zR9cbeDoSKtdGUS1Svty+k29deMPiIM4u/ayzog==",
+            "version": "3.1039.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.1039.0.tgz",
+            "integrity": "sha512-iT3IEdr2CriBy2h5LR/+O5PadxAoLNFepQ+I7pwPam77e3OhkivMUQJ/7vOfh6HGU0Mh2SENJBOO6xaAenC9fA==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@aws-crypto/sha256-browser": "3.0.0",
-                "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sts": "3.414.0",
-                "@aws-sdk/credential-provider-node": "3.414.0",
-                "@aws-sdk/middleware-host-header": "3.413.0",
-                "@aws-sdk/middleware-logger": "3.413.0",
-                "@aws-sdk/middleware-recursion-detection": "3.413.0",
-                "@aws-sdk/middleware-signing": "3.413.0",
-                "@aws-sdk/middleware-user-agent": "3.413.0",
-                "@aws-sdk/region-config-resolver": "3.413.0",
-                "@aws-sdk/types": "3.413.0",
-                "@aws-sdk/util-endpoints": "3.413.0",
-                "@aws-sdk/util-user-agent-browser": "3.413.0",
-                "@aws-sdk/util-user-agent-node": "3.413.0",
-                "@smithy/config-resolver": "^2.0.8",
-                "@smithy/fetch-http-handler": "^2.1.3",
-                "@smithy/hash-node": "^2.0.7",
-                "@smithy/invalid-dependency": "^2.0.7",
-                "@smithy/middleware-content-length": "^2.0.9",
-                "@smithy/middleware-endpoint": "^2.0.7",
-                "@smithy/middleware-retry": "^2.0.10",
-                "@smithy/middleware-serde": "^2.0.7",
-                "@smithy/middleware-stack": "^2.0.0",
-                "@smithy/node-config-provider": "^2.0.10",
-                "@smithy/node-http-handler": "^2.1.3",
-                "@smithy/protocol-http": "^3.0.3",
-                "@smithy/smithy-client": "^2.1.4",
-                "@smithy/types": "^2.3.1",
-                "@smithy/url-parser": "^2.0.7",
-                "@smithy/util-base64": "^2.0.0",
-                "@smithy/util-body-length-browser": "^2.0.0",
-                "@smithy/util-body-length-node": "^2.1.0",
-                "@smithy/util-defaults-mode-browser": "^2.0.8",
-                "@smithy/util-defaults-mode-node": "^2.0.10",
-                "@smithy/util-retry": "^2.0.0",
-                "@smithy/util-utf8": "^2.0.0",
-                "@smithy/util-waiter": "^2.0.7",
-                "fast-xml-parser": "4.2.5",
-                "tslib": "^2.5.0",
-                "uuid": "^8.3.2"
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "^3.974.7",
+                "@aws-sdk/credential-provider-node": "^3.972.38",
+                "@aws-sdk/middleware-host-header": "^3.972.10",
+                "@aws-sdk/middleware-logger": "^3.972.10",
+                "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+                "@aws-sdk/middleware-user-agent": "^3.972.37",
+                "@aws-sdk/region-config-resolver": "^3.972.13",
+                "@aws-sdk/types": "^3.973.8",
+                "@aws-sdk/util-endpoints": "^3.996.8",
+                "@aws-sdk/util-user-agent-browser": "^3.972.10",
+                "@aws-sdk/util-user-agent-node": "^3.973.23",
+                "@smithy/config-resolver": "^4.4.17",
+                "@smithy/core": "^3.23.17",
+                "@smithy/fetch-http-handler": "^5.3.17",
+                "@smithy/hash-node": "^4.2.14",
+                "@smithy/invalid-dependency": "^4.2.14",
+                "@smithy/middleware-content-length": "^4.2.14",
+                "@smithy/middleware-endpoint": "^4.4.32",
+                "@smithy/middleware-retry": "^4.5.7",
+                "@smithy/middleware-serde": "^4.2.20",
+                "@smithy/middleware-stack": "^4.2.14",
+                "@smithy/node-config-provider": "^4.3.14",
+                "@smithy/node-http-handler": "^4.6.1",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/smithy-client": "^4.12.13",
+                "@smithy/types": "^4.14.1",
+                "@smithy/url-parser": "^4.2.14",
+                "@smithy/util-base64": "^4.3.2",
+                "@smithy/util-body-length-browser": "^4.2.2",
+                "@smithy/util-body-length-node": "^4.2.3",
+                "@smithy/util-defaults-mode-browser": "^4.3.49",
+                "@smithy/util-defaults-mode-node": "^4.2.54",
+                "@smithy/util-endpoints": "^3.4.2",
+                "@smithy/util-middleware": "^4.2.14",
+                "@smithy/util-retry": "^4.3.6",
+                "@smithy/util-utf8": "^4.2.2",
+                "@smithy/util-waiter": "^4.3.0",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso": {
-            "version": "3.414.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.414.0.tgz",
-            "integrity": "sha512-GvRwQ7wA3edzsQEKS70ZPhkOUZ62PAiXasjp6GxrsADEb8sV1z4FxXNl9Un/7fQxKkh9QYaK1Wu1PmhLi9MLMg==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "@aws-crypto/sha256-browser": "3.0.0",
-                "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/middleware-host-header": "3.413.0",
-                "@aws-sdk/middleware-logger": "3.413.0",
-                "@aws-sdk/middleware-recursion-detection": "3.413.0",
-                "@aws-sdk/middleware-user-agent": "3.413.0",
-                "@aws-sdk/region-config-resolver": "3.413.0",
-                "@aws-sdk/types": "3.413.0",
-                "@aws-sdk/util-endpoints": "3.413.0",
-                "@aws-sdk/util-user-agent-browser": "3.413.0",
-                "@aws-sdk/util-user-agent-node": "3.413.0",
-                "@smithy/config-resolver": "^2.0.8",
-                "@smithy/fetch-http-handler": "^2.1.3",
-                "@smithy/hash-node": "^2.0.7",
-                "@smithy/invalid-dependency": "^2.0.7",
-                "@smithy/middleware-content-length": "^2.0.9",
-                "@smithy/middleware-endpoint": "^2.0.7",
-                "@smithy/middleware-retry": "^2.0.10",
-                "@smithy/middleware-serde": "^2.0.7",
-                "@smithy/middleware-stack": "^2.0.0",
-                "@smithy/node-config-provider": "^2.0.10",
-                "@smithy/node-http-handler": "^2.1.3",
-                "@smithy/protocol-http": "^3.0.3",
-                "@smithy/smithy-client": "^2.1.4",
-                "@smithy/types": "^2.3.1",
-                "@smithy/url-parser": "^2.0.7",
-                "@smithy/util-base64": "^2.0.0",
-                "@smithy/util-body-length-browser": "^2.0.0",
-                "@smithy/util-body-length-node": "^2.1.0",
-                "@smithy/util-defaults-mode-browser": "^2.0.8",
-                "@smithy/util-defaults-mode-node": "^2.0.10",
-                "@smithy/util-retry": "^2.0.0",
-                "@smithy/util-utf8": "^2.0.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/client-sts": {
-            "version": "3.414.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.414.0.tgz",
-            "integrity": "sha512-xeYH3si6Imp1EWolWn1zuxJJu2AXKwXl1HDftQULwC5AWkm1mNFbXYSJN4hQul1IM+kn+JTRB0XRHByQkKhe+Q==",
+            "version": "3.1039.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.1039.0.tgz",
+            "integrity": "sha512-FKwfa4agOd6rctrp6D+W/sUKT+c+wI5m23oYR0VyE01oad6ZYff+113JP/X2xbrxIFJtVz7GieQZdVUFqOuMuQ==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@aws-crypto/sha256-browser": "3.0.0",
-                "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/credential-provider-node": "3.414.0",
-                "@aws-sdk/middleware-host-header": "3.413.0",
-                "@aws-sdk/middleware-logger": "3.413.0",
-                "@aws-sdk/middleware-recursion-detection": "3.413.0",
-                "@aws-sdk/middleware-sdk-sts": "3.413.0",
-                "@aws-sdk/middleware-signing": "3.413.0",
-                "@aws-sdk/middleware-user-agent": "3.413.0",
-                "@aws-sdk/region-config-resolver": "3.413.0",
-                "@aws-sdk/types": "3.413.0",
-                "@aws-sdk/util-endpoints": "3.413.0",
-                "@aws-sdk/util-user-agent-browser": "3.413.0",
-                "@aws-sdk/util-user-agent-node": "3.413.0",
-                "@smithy/config-resolver": "^2.0.8",
-                "@smithy/fetch-http-handler": "^2.1.3",
-                "@smithy/hash-node": "^2.0.7",
-                "@smithy/invalid-dependency": "^2.0.7",
-                "@smithy/middleware-content-length": "^2.0.9",
-                "@smithy/middleware-endpoint": "^2.0.7",
-                "@smithy/middleware-retry": "^2.0.10",
-                "@smithy/middleware-serde": "^2.0.7",
-                "@smithy/middleware-stack": "^2.0.0",
-                "@smithy/node-config-provider": "^2.0.10",
-                "@smithy/node-http-handler": "^2.1.3",
-                "@smithy/protocol-http": "^3.0.3",
-                "@smithy/smithy-client": "^2.1.4",
-                "@smithy/types": "^2.3.1",
-                "@smithy/url-parser": "^2.0.7",
-                "@smithy/util-base64": "^2.0.0",
-                "@smithy/util-body-length-browser": "^2.0.0",
-                "@smithy/util-body-length-node": "^2.1.0",
-                "@smithy/util-defaults-mode-browser": "^2.0.8",
-                "@smithy/util-defaults-mode-node": "^2.0.10",
-                "@smithy/util-retry": "^2.0.0",
-                "@smithy/util-utf8": "^2.0.0",
-                "fast-xml-parser": "4.2.5",
-                "tslib": "^2.5.0"
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "^3.974.7",
+                "@aws-sdk/credential-provider-node": "^3.972.38",
+                "@aws-sdk/middleware-host-header": "^3.972.10",
+                "@aws-sdk/middleware-logger": "^3.972.10",
+                "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+                "@aws-sdk/middleware-user-agent": "^3.972.37",
+                "@aws-sdk/region-config-resolver": "^3.972.13",
+                "@aws-sdk/signature-v4-multi-region": "^3.996.24",
+                "@aws-sdk/types": "^3.973.8",
+                "@aws-sdk/util-endpoints": "^3.996.8",
+                "@aws-sdk/util-user-agent-browser": "^3.972.10",
+                "@aws-sdk/util-user-agent-node": "^3.973.23",
+                "@smithy/config-resolver": "^4.4.17",
+                "@smithy/core": "^3.23.17",
+                "@smithy/fetch-http-handler": "^5.3.17",
+                "@smithy/hash-node": "^4.2.14",
+                "@smithy/invalid-dependency": "^4.2.14",
+                "@smithy/middleware-content-length": "^4.2.14",
+                "@smithy/middleware-endpoint": "^4.4.32",
+                "@smithy/middleware-retry": "^4.5.7",
+                "@smithy/middleware-serde": "^4.2.20",
+                "@smithy/middleware-stack": "^4.2.14",
+                "@smithy/node-config-provider": "^4.3.14",
+                "@smithy/node-http-handler": "^4.6.1",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/smithy-client": "^4.12.13",
+                "@smithy/types": "^4.14.1",
+                "@smithy/url-parser": "^4.2.14",
+                "@smithy/util-base64": "^4.3.2",
+                "@smithy/util-body-length-browser": "^4.2.2",
+                "@smithy/util-body-length-node": "^4.2.3",
+                "@smithy/util-defaults-mode-browser": "^4.3.49",
+                "@smithy/util-defaults-mode-node": "^4.2.54",
+                "@smithy/util-endpoints": "^3.4.2",
+                "@smithy/util-middleware": "^4.2.14",
+                "@smithy/util-retry": "^4.3.6",
+                "@smithy/util-utf8": "^4.2.2",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/core": {
+            "version": "3.974.7",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.7.tgz",
+            "integrity": "sha512-YhRC90ofz5oolTJZlA8voU/oUrCB2azi8Usx51k8hhB5LpWbYQMMXKUqSqkoL0Cru+RQJgWTHpAfEDDIwfUhJw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/types": "^3.973.8",
+                "@aws-sdk/xml-builder": "^3.972.22",
+                "@smithy/core": "^3.23.17",
+                "@smithy/node-config-provider": "^4.3.14",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/signature-v4": "^5.3.14",
+                "@smithy/smithy-client": "^4.12.13",
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-base64": "^4.3.2",
+                "@smithy/util-middleware": "^4.2.14",
+                "@smithy/util-retry": "^4.3.6",
+                "@smithy/util-utf8": "^4.2.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-env": {
-            "version": "3.413.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.413.0.tgz",
-            "integrity": "sha512-yeMOkfG20/RlzfPMtQuDB647AcPEvFEVYOWZzAWVJfldYQ5ybKr0d7sBkgG9sdAzGkK3Aw9dE4rigYI8EIqc1Q==",
+            "version": "3.972.33",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.33.tgz",
+            "integrity": "sha512-bJV7eViSJV6GSuuN+VIdNVPdwPsNSf75BiC2v5alPrjR/OCcqgKwSZInKbDFz9mNeizldsyf67jt6YSIiv53Cw==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@aws-sdk/types": "3.413.0",
-                "@smithy/property-provider": "^2.0.0",
-                "@smithy/types": "^2.3.1",
-                "tslib": "^2.5.0"
+                "@aws-sdk/core": "^3.974.7",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-http": {
+            "version": "3.972.35",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.35.tgz",
+            "integrity": "sha512-x/BQGEIdq0oI+4WxLjKmnQvT7CnF9r8ezdGt7wXwxb7ckHXQz0Zmgxt8v3Ne0JaT3R5YefmuybHX6E8EnsDXyA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/core": "^3.974.7",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/fetch-http-handler": "^5.3.17",
+                "@smithy/node-http-handler": "^4.6.1",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/smithy-client": "^4.12.13",
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-stream": "^4.5.25",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-ini": {
-            "version": "3.414.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.414.0.tgz",
-            "integrity": "sha512-rlpLLx70roJL/t40opWC96LbIASejdMbRlgSCRpK8b/hKngYDe5A7SRVacaw08vYrAywxRiybxpQOwOt9b++rA==",
+            "version": "3.972.37",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.37.tgz",
+            "integrity": "sha512-eUTpmWfd/BKsq9medhCRcu+GRAhFP2Zrn7/2jKDHHOOjCkhrMoTp/t4cEthqFoG7gE0VGp5wUxrXTdvBCmSmJg==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.413.0",
-                "@aws-sdk/credential-provider-process": "3.413.0",
-                "@aws-sdk/credential-provider-sso": "3.414.0",
-                "@aws-sdk/credential-provider-web-identity": "3.413.0",
-                "@aws-sdk/types": "3.413.0",
-                "@smithy/credential-provider-imds": "^2.0.0",
-                "@smithy/property-provider": "^2.0.0",
-                "@smithy/shared-ini-file-loader": "^2.0.6",
-                "@smithy/types": "^2.3.1",
-                "tslib": "^2.5.0"
+                "@aws-sdk/core": "^3.974.7",
+                "@aws-sdk/credential-provider-env": "^3.972.33",
+                "@aws-sdk/credential-provider-http": "^3.972.35",
+                "@aws-sdk/credential-provider-login": "^3.972.37",
+                "@aws-sdk/credential-provider-process": "^3.972.33",
+                "@aws-sdk/credential-provider-sso": "^3.972.37",
+                "@aws-sdk/credential-provider-web-identity": "^3.972.37",
+                "@aws-sdk/nested-clients": "^3.997.5",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/credential-provider-imds": "^4.2.14",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/shared-ini-file-loader": "^4.4.9",
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-login": {
+            "version": "3.972.37",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.37.tgz",
+            "integrity": "sha512-Ty68y8ISSC+g5Q3D0K8uAaoINwvfaOslnNpsF/LgVUxyosYXHawcK2yV4HLXDVugiTTYLQfJfcw0ce5meAGkKw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/core": "^3.974.7",
+                "@aws-sdk/nested-clients": "^3.997.5",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/shared-ini-file-loader": "^4.4.9",
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.414.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.414.0.tgz",
-            "integrity": "sha512-xlkcOUKeGHInxWKKrZKIPSBCUL/ozyCldJBjmMKEj7ZmBAEiDcjpMe3pZ//LibMkCSy0b/7jtyQBE/eaIT2o0A==",
+            "version": "3.972.38",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.38.tgz",
+            "integrity": "sha512-BQ9XYnBDVxR2HuV5huXYQYF/PZMTsY+EnwfGnCU2cA8Zw63XpkOtPY8WqiMIZMQCrKPQQEiFURS/o9CIolRLqg==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.413.0",
-                "@aws-sdk/credential-provider-ini": "3.414.0",
-                "@aws-sdk/credential-provider-process": "3.413.0",
-                "@aws-sdk/credential-provider-sso": "3.414.0",
-                "@aws-sdk/credential-provider-web-identity": "3.413.0",
-                "@aws-sdk/types": "3.413.0",
-                "@smithy/credential-provider-imds": "^2.0.0",
-                "@smithy/property-provider": "^2.0.0",
-                "@smithy/shared-ini-file-loader": "^2.0.6",
-                "@smithy/types": "^2.3.1",
-                "tslib": "^2.5.0"
+                "@aws-sdk/credential-provider-env": "^3.972.33",
+                "@aws-sdk/credential-provider-http": "^3.972.35",
+                "@aws-sdk/credential-provider-ini": "^3.972.37",
+                "@aws-sdk/credential-provider-process": "^3.972.33",
+                "@aws-sdk/credential-provider-sso": "^3.972.37",
+                "@aws-sdk/credential-provider-web-identity": "^3.972.37",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/credential-provider-imds": "^4.2.14",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/shared-ini-file-loader": "^4.4.9",
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-process": {
-            "version": "3.413.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.413.0.tgz",
-            "integrity": "sha512-GFJdgS14GzJ1wc2DEnS44Z/34iBZ05CAkvDsLN2CMwcDgH4eZuif9/x0lwzIJBK3xVFHzYUeVvEzsqRPbCHRsw==",
+            "version": "3.972.33",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.33.tgz",
+            "integrity": "sha512-yfjGksI9WQbdMObb0VeLXqzTLI+a0qXLJT9gCDiv0+X/xjPpI3mTz6a5FibrhpuEKIe0gSgvs3MaoFZy5cx4WA==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@aws-sdk/types": "3.413.0",
-                "@smithy/property-provider": "^2.0.0",
-                "@smithy/shared-ini-file-loader": "^2.0.6",
-                "@smithy/types": "^2.3.1",
-                "tslib": "^2.5.0"
+                "@aws-sdk/core": "^3.974.7",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/shared-ini-file-loader": "^4.4.9",
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-sso": {
-            "version": "3.414.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.414.0.tgz",
-            "integrity": "sha512-w9g2hlkZn7WekWICRqk+L33py7KrjYMFryVpkKXOx2pjDchCfZDr6pL1ml782GZ0L3qsob4SbNpbtp13JprnWQ==",
+            "version": "3.972.37",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.37.tgz",
+            "integrity": "sha512-fpwE+20ntpp3i9Xb9vUuQfXLDKYHH+5I2V+ZG96SX1nBzrruhy10RXDgmN7t1etOz3c55stlA3TeQASUA451NQ==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@aws-sdk/client-sso": "3.414.0",
-                "@aws-sdk/token-providers": "3.413.0",
-                "@aws-sdk/types": "3.413.0",
-                "@smithy/property-provider": "^2.0.0",
-                "@smithy/shared-ini-file-loader": "^2.0.6",
-                "@smithy/types": "^2.3.1",
-                "tslib": "^2.5.0"
+                "@aws-sdk/core": "^3.974.7",
+                "@aws-sdk/nested-clients": "^3.997.5",
+                "@aws-sdk/token-providers": "3.1039.0",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/shared-ini-file-loader": "^4.4.9",
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-web-identity": {
-            "version": "3.413.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.413.0.tgz",
-            "integrity": "sha512-5cdA1Iq9JeEHtg59ERV9fdMQ7cS0JF6gH/BWA7HYEUGdSVPXCuwyEggPtG64QgpNU7SmxH+QdDG+Ldxz09ycIA==",
+            "version": "3.972.37",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.37.tgz",
+            "integrity": "sha512-aryawqyebf+3WhAFNHfF62rekFpYtVcVN7dQ89qnAWsa4n5hJst8qBG6gXC24WHtW7Nnhkf9ScYnjwo0Brn3bw==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@aws-sdk/types": "3.413.0",
-                "@smithy/property-provider": "^2.0.0",
-                "@smithy/types": "^2.3.1",
-                "tslib": "^2.5.0"
+                "@aws-sdk/core": "^3.974.7",
+                "@aws-sdk/nested-clients": "^3.997.5",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/shared-ini-file-loader": "^4.4.9",
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/middleware-host-header": {
-            "version": "3.413.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.413.0.tgz",
-            "integrity": "sha512-r9PQx468EzPHo9wRzZLfgROpKtVdbkteMrdhsuM12bifVHjU1OHr7yfhc1OdWv39X8Xiv6F8n5r+RBQEM0S6+g==",
+            "version": "3.972.10",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
+            "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@aws-sdk/types": "3.413.0",
-                "@smithy/protocol-http": "^3.0.3",
-                "@smithy/types": "^2.3.1",
-                "tslib": "^2.5.0"
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/middleware-logger": {
-            "version": "3.413.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.413.0.tgz",
-            "integrity": "sha512-jqcXDubcKvoqBy+kkEa0WoNjG6SveDeyNy+gdGnTV+DEtYjkcHrHJei4q0W5zFl0mzc+dP+z8tJF44rv95ZY3Q==",
+            "version": "3.972.10",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
+            "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@aws-sdk/types": "3.413.0",
-                "@smithy/types": "^2.3.1",
-                "tslib": "^2.5.0"
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/middleware-recursion-detection": {
-            "version": "3.413.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.413.0.tgz",
-            "integrity": "sha512-C6k0IKJk/A4/VBGwUjxEPG+WOjjnmWAZVRBUzaeM7PqRh+g5rLcuIV356ntV3pREVxyiSTePTYVYIHU9YXkLKQ==",
+            "version": "3.972.11",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
+            "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@aws-sdk/types": "3.413.0",
-                "@smithy/protocol-http": "^3.0.3",
-                "@smithy/types": "^2.3.1",
-                "tslib": "^2.5.0"
+                "@aws-sdk/types": "^3.973.8",
+                "@aws/lambda-invoke-store": "^0.2.2",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=20.0.0"
             }
         },
-        "node_modules/@aws-sdk/middleware-sdk-sts": {
-            "version": "3.413.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.413.0.tgz",
-            "integrity": "sha512-t0u//JUyaEZRVnH5q+Ur3tWnuyIsTdwA0XOdDCZXcSlLYzGp2MI/tScLjn9IydRrceIFpFfmbjk4Nf/Q6TeBTQ==",
+        "node_modules/@aws-sdk/middleware-sdk-s3": {
+            "version": "3.972.36",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.36.tgz",
+            "integrity": "sha512-YhPix+0x/MdQrb1Ug1GDKeS5fqylIy+naz800asX8II4jqfTk2KY2KhmmYCwZcky8YWtRQQwWCGdoqeAnip8Uw==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@aws-sdk/middleware-signing": "3.413.0",
-                "@aws-sdk/types": "3.413.0",
-                "@smithy/types": "^2.3.1",
-                "tslib": "^2.5.0"
+                "@aws-sdk/core": "^3.974.7",
+                "@aws-sdk/types": "^3.973.8",
+                "@aws-sdk/util-arn-parser": "^3.972.3",
+                "@smithy/core": "^3.23.17",
+                "@smithy/node-config-provider": "^4.3.14",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/signature-v4": "^5.3.14",
+                "@smithy/smithy-client": "^4.12.13",
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-config-provider": "^4.2.2",
+                "@smithy/util-middleware": "^4.2.14",
+                "@smithy/util-stream": "^4.5.25",
+                "@smithy/util-utf8": "^4.2.2",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-signing": {
-            "version": "3.413.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.413.0.tgz",
-            "integrity": "sha512-QFEnVvIKYPCermM+ESxEztgUgXzGSKpnPnohMYNvSZySqmOLu/4VvxiZbRO/BX9J3ZHcUgaw4vKm5VBZRrycxw==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/types": "3.413.0",
-                "@smithy/property-provider": "^2.0.0",
-                "@smithy/protocol-http": "^3.0.3",
-                "@smithy/signature-v4": "^2.0.0",
-                "@smithy/types": "^2.3.1",
-                "@smithy/util-middleware": "^2.0.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/middleware-user-agent": {
-            "version": "3.413.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.413.0.tgz",
-            "integrity": "sha512-eVMJyeWxNBqerhfD+sE9sTjDtwQiECrfU6wpUQP5fGPhJD2cVVZPxuTuJGDZCu/4k/V61dF85IYlsPUNLdVQ6w==",
+            "version": "3.972.37",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.37.tgz",
+            "integrity": "sha512-N1oNpdiLoVAWYD3WFBnUi3LlfoDA06ZHo4ozyjbsJNLvILzvt//0CnR8N+CZ0NWeYgVB/5V59ivixHCWCx2ALw==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@aws-sdk/types": "3.413.0",
-                "@aws-sdk/util-endpoints": "3.413.0",
-                "@smithy/protocol-http": "^3.0.3",
-                "@smithy/types": "^2.3.1",
-                "tslib": "^2.5.0"
+                "@aws-sdk/core": "^3.974.7",
+                "@aws-sdk/types": "^3.973.8",
+                "@aws-sdk/util-endpoints": "^3.996.8",
+                "@smithy/core": "^3.23.17",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-retry": "^4.3.6",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients": {
+            "version": "3.997.5",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.5.tgz",
+            "integrity": "sha512-jGFr6DxtcMTmzOkG/a0jCZYv4BBDmeNYVeO+/memSoDkYCJu4Y58xviYmzwJfYyIVSts+X/BVjJm1uGBnwHEMg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "^3.974.7",
+                "@aws-sdk/middleware-host-header": "^3.972.10",
+                "@aws-sdk/middleware-logger": "^3.972.10",
+                "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+                "@aws-sdk/middleware-user-agent": "^3.972.37",
+                "@aws-sdk/region-config-resolver": "^3.972.13",
+                "@aws-sdk/signature-v4-multi-region": "^3.996.24",
+                "@aws-sdk/types": "^3.973.8",
+                "@aws-sdk/util-endpoints": "^3.996.8",
+                "@aws-sdk/util-user-agent-browser": "^3.972.10",
+                "@aws-sdk/util-user-agent-node": "^3.973.23",
+                "@smithy/config-resolver": "^4.4.17",
+                "@smithy/core": "^3.23.17",
+                "@smithy/fetch-http-handler": "^5.3.17",
+                "@smithy/hash-node": "^4.2.14",
+                "@smithy/invalid-dependency": "^4.2.14",
+                "@smithy/middleware-content-length": "^4.2.14",
+                "@smithy/middleware-endpoint": "^4.4.32",
+                "@smithy/middleware-retry": "^4.5.7",
+                "@smithy/middleware-serde": "^4.2.20",
+                "@smithy/middleware-stack": "^4.2.14",
+                "@smithy/node-config-provider": "^4.3.14",
+                "@smithy/node-http-handler": "^4.6.1",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/smithy-client": "^4.12.13",
+                "@smithy/types": "^4.14.1",
+                "@smithy/url-parser": "^4.2.14",
+                "@smithy/util-base64": "^4.3.2",
+                "@smithy/util-body-length-browser": "^4.2.2",
+                "@smithy/util-body-length-node": "^4.2.3",
+                "@smithy/util-defaults-mode-browser": "^4.3.49",
+                "@smithy/util-defaults-mode-node": "^4.2.54",
+                "@smithy/util-endpoints": "^3.4.2",
+                "@smithy/util-middleware": "^4.2.14",
+                "@smithy/util-retry": "^4.3.6",
+                "@smithy/util-utf8": "^4.2.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/region-config-resolver": {
-            "version": "3.413.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.413.0.tgz",
-            "integrity": "sha512-h90e6yyOhvoc+1F5vFk3C5mxwB8RSDEMKTO/fxexyur94seczZ1yxyYkTMZv30oc9RUiToABlHNrh/wxL7TZPQ==",
+            "version": "3.972.13",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
+            "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@smithy/node-config-provider": "^2.0.10",
-                "@smithy/types": "^2.3.1",
-                "@smithy/util-config-provider": "^2.0.0",
-                "@smithy/util-middleware": "^2.0.0",
-                "tslib": "^2.5.0"
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/config-resolver": "^4.4.17",
+                "@smithy/node-config-provider": "^4.3.14",
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/signature-v4-multi-region": {
+            "version": "3.996.24",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.24.tgz",
+            "integrity": "sha512-amP7tLikppN940wbBFISYqiuzVmpzMS9U3mcgtmVLjX4fdWI/SNCvrXv6ZxfVzTT4cT0rPKOLhFah2xLwzREWw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/middleware-sdk-s3": "^3.972.36",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/signature-v4": "^5.3.14",
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/token-providers": {
-            "version": "3.413.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.413.0.tgz",
-            "integrity": "sha512-NfP1Ib9LAWVLMTOa/1aJwt4TRrlRrNyukCpVZGfNaMnNNEoP5Rakdbcs8KFVHe/MJzU+GdKVzxQ4TgRkLOGTrA==",
+            "version": "3.1039.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1039.0.tgz",
+            "integrity": "sha512-NMSFL2HwkAOoCeLCQiqoOq5pT3vVbSjww2QZTuYgYknVwhhv125PSDzZIcL5EYnlxuPWjEOdauZK+FspkZDVdw==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@aws-crypto/sha256-browser": "3.0.0",
-                "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/middleware-host-header": "3.413.0",
-                "@aws-sdk/middleware-logger": "3.413.0",
-                "@aws-sdk/middleware-recursion-detection": "3.413.0",
-                "@aws-sdk/middleware-user-agent": "3.413.0",
-                "@aws-sdk/types": "3.413.0",
-                "@aws-sdk/util-endpoints": "3.413.0",
-                "@aws-sdk/util-user-agent-browser": "3.413.0",
-                "@aws-sdk/util-user-agent-node": "3.413.0",
-                "@smithy/config-resolver": "^2.0.8",
-                "@smithy/fetch-http-handler": "^2.1.3",
-                "@smithy/hash-node": "^2.0.7",
-                "@smithy/invalid-dependency": "^2.0.7",
-                "@smithy/middleware-content-length": "^2.0.9",
-                "@smithy/middleware-endpoint": "^2.0.7",
-                "@smithy/middleware-retry": "^2.0.10",
-                "@smithy/middleware-serde": "^2.0.7",
-                "@smithy/middleware-stack": "^2.0.0",
-                "@smithy/node-config-provider": "^2.0.10",
-                "@smithy/node-http-handler": "^2.1.3",
-                "@smithy/property-provider": "^2.0.0",
-                "@smithy/protocol-http": "^3.0.3",
-                "@smithy/shared-ini-file-loader": "^2.0.6",
-                "@smithy/smithy-client": "^2.1.4",
-                "@smithy/types": "^2.3.1",
-                "@smithy/url-parser": "^2.0.7",
-                "@smithy/util-base64": "^2.0.0",
-                "@smithy/util-body-length-browser": "^2.0.0",
-                "@smithy/util-body-length-node": "^2.1.0",
-                "@smithy/util-defaults-mode-browser": "^2.0.8",
-                "@smithy/util-defaults-mode-node": "^2.0.10",
-                "@smithy/util-retry": "^2.0.0",
-                "@smithy/util-utf8": "^2.0.0",
-                "tslib": "^2.5.0"
+                "@aws-sdk/core": "^3.974.7",
+                "@aws-sdk/nested-clients": "^3.997.5",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/shared-ini-file-loader": "^4.4.9",
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/types": {
-            "version": "3.413.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.413.0.tgz",
-            "integrity": "sha512-j1xib0f/TazIFc5ySIKOlT1ujntRbaoG4LJFeEezz4ji03/wSJMI8Vi4KjzpBp8J1tTu0oRDnsxRIGixsUBeYQ==",
+            "version": "3.973.8",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+            "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@smithy/types": "^2.3.1",
-                "tslib": "^2.5.0"
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-arn-parser": {
+            "version": "3.972.3",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.3.tgz",
+            "integrity": "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/util-endpoints": {
-            "version": "3.413.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.413.0.tgz",
-            "integrity": "sha512-VAwr7cITNb1L6/2XUPIbCOuhKGm0VtKCRblurrfUF2bxqG/wtuw/2Fm4ahYJPyxklOSXAMSq+RHdFWcir0YB/g==",
+            "version": "3.996.8",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
+            "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@aws-sdk/types": "3.413.0",
-                "tslib": "^2.5.0"
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/types": "^4.14.1",
+                "@smithy/url-parser": "^4.2.14",
+                "@smithy/util-endpoints": "^3.4.2",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/util-locate-window": {
-            "version": "3.310.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.310.0.tgz",
-            "integrity": "sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==",
+            "version": "3.965.5",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+            "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "tslib": "^2.5.0"
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/util-user-agent-browser": {
-            "version": "3.413.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.413.0.tgz",
-            "integrity": "sha512-7j/qWcRO2OBZBre2fC6V6M0PAS9n7k6i+VtofPkkhxC2DZszLJElqnooF9hGmVGYK3zR47Np4WjURXKIEZclWg==",
+            "version": "3.972.10",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
+            "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@aws-sdk/types": "3.413.0",
-                "@smithy/types": "^2.3.1",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/types": "^4.14.1",
                 "bowser": "^2.11.0",
-                "tslib": "^2.5.0"
+                "tslib": "^2.6.2"
             }
         },
         "node_modules/@aws-sdk/util-user-agent-node": {
-            "version": "3.413.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.413.0.tgz",
-            "integrity": "sha512-vHm9TVZIzfWMeDvdmoOky6VarqOt8Pr68CESHN0jyuO6XbhCDnr9rpaXiBhbSR+N1Qm7R/AfJgAhQyTMu2G1OA==",
+            "version": "3.973.23",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.23.tgz",
+            "integrity": "sha512-gGwq8L2Euw0aNG6Ey4EktiAo3fSCVoDy1CaBIthd+oeaKHPXUrNaApMewQ6La5Hv0lcznOtECZaNvYyc5LXXfA==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@aws-sdk/types": "3.413.0",
-                "@smithy/node-config-provider": "^2.0.10",
-                "@smithy/types": "^2.3.1",
-                "tslib": "^2.5.0"
+                "@aws-sdk/middleware-user-agent": "^3.972.37",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/node-config-provider": "^4.3.14",
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-config-provider": "^4.2.2",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=20.0.0"
             },
             "peerDependencies": {
                 "aws-crt": ">=1.0.0"
@@ -701,14 +846,32 @@
                 }
             }
         },
-        "node_modules/@aws-sdk/util-utf8-browser": {
-            "version": "3.259.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
-            "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+        "node_modules/@aws-sdk/xml-builder": {
+            "version": "3.972.22",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.22.tgz",
+            "integrity": "sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "tslib": "^2.3.1"
+                "@nodable/entities": "2.1.0",
+                "@smithy/types": "^4.14.1",
+                "fast-xml-parser": "5.7.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws/lambda-invoke-store": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+            "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "engines": {
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -1729,6 +1892,20 @@
             "dev": true,
             "peer": true
         },
+        "node_modules/@nodable/entities": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+            "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodable"
+                }
+            ],
+            "license": "MIT",
+            "peer": true
+        },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1765,16 +1942,17 @@
             }
         },
         "node_modules/@serverless/dashboard-plugin": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/@serverless/dashboard-plugin/-/dashboard-plugin-7.0.3.tgz",
-            "integrity": "sha512-rnVMyD4+IOFbsK4dxt541YaS0Lpia6DHXV01AFA5YnAwzVBlX4gSxx9aIQPkpx0PvB1A1S3rPgx/gfACWmdbgQ==",
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/@serverless/dashboard-plugin/-/dashboard-plugin-7.2.3.tgz",
+            "integrity": "sha512-Vu4TKJLEQ5F8ZipfCvd8A/LMIdH8kNGe448sX9mT4/Z0JVUaYmMc3BwkQ+zkNIh3QdBKAhocGn45TYjHV6uPWQ==",
             "dev": true,
+            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@aws-sdk/client-cloudformation": "^3.410.0",
                 "@aws-sdk/client-sts": "^3.410.0",
                 "@serverless/event-mocks": "^1.1.1",
-                "@serverless/platform-client": "^4.4.0",
+                "@serverless/platform-client": "^4.5.1",
                 "@serverless/utils": "^6.14.0",
                 "child-process-ext": "^3.0.1",
                 "chokidar": "^3.5.3",
@@ -2133,581 +2311,665 @@
                 "@sinonjs/commons": "^1.7.0"
             }
         },
-        "node_modules/@smithy/abort-controller": {
-            "version": "2.0.9",
-            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.9.tgz",
-            "integrity": "sha512-8liHOEbx99xcy4VndeQNQhyA0LS+e7UqsuRnDTSIA26IKBv/7vA9w09KOd4fgNULrvX0r3WpA6cwsQTRJpSWkg==",
+        "node_modules/@smithy/config-resolver": {
+            "version": "4.4.17",
+            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.17.tgz",
+            "integrity": "sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@smithy/types": "^2.3.3",
-                "tslib": "^2.5.0"
+                "@smithy/node-config-provider": "^4.3.14",
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-config-provider": "^4.2.2",
+                "@smithy/util-endpoints": "^3.4.2",
+                "@smithy/util-middleware": "^4.2.14",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=18.0.0"
             }
         },
-        "node_modules/@smithy/config-resolver": {
-            "version": "2.0.10",
-            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.10.tgz",
-            "integrity": "sha512-MwToDsCltHjumkCuRn883qoNeJUawc2b8sX9caSn5vLz6J5crU1IklklNxWCaMO2z2nDL91Po4b/aI1eHv5PfA==",
+        "node_modules/@smithy/core": {
+            "version": "3.23.17",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.17.tgz",
+            "integrity": "sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@smithy/node-config-provider": "^2.0.12",
-                "@smithy/types": "^2.3.3",
-                "@smithy/util-config-provider": "^2.0.0",
-                "@smithy/util-middleware": "^2.0.2",
-                "tslib": "^2.5.0"
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/types": "^4.14.1",
+                "@smithy/url-parser": "^4.2.14",
+                "@smithy/util-base64": "^4.3.2",
+                "@smithy/util-body-length-browser": "^4.2.2",
+                "@smithy/util-middleware": "^4.2.14",
+                "@smithy/util-stream": "^4.5.25",
+                "@smithy/util-utf8": "^4.2.2",
+                "@smithy/uuid": "^1.1.2",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@smithy/credential-provider-imds": {
-            "version": "2.0.12",
-            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.12.tgz",
-            "integrity": "sha512-S3lUNe+2fEFwKcmiQniXGPXt69vaHvQCw8kYQOBL4OvJsgwfpkIYDZdroHbTshYi0M6WaKL26Mw+hvgma6dZqA==",
+            "version": "4.2.14",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.14.tgz",
+            "integrity": "sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@smithy/node-config-provider": "^2.0.12",
-                "@smithy/property-provider": "^2.0.10",
-                "@smithy/types": "^2.3.3",
-                "@smithy/url-parser": "^2.0.9",
-                "tslib": "^2.5.0"
+                "@smithy/node-config-provider": "^4.3.14",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/types": "^4.14.1",
+                "@smithy/url-parser": "^4.2.14",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@smithy/eventstream-codec": {
-            "version": "2.0.9",
-            "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.9.tgz",
-            "integrity": "sha512-sy0pcbKnawt1iu+qCoSFbs/h9PAaUgvlJEO3lqkE1HFFj4p5RgL98vH+9CyDoj6YY82cG5XsorFmcLqQJHTOYw==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "@aws-crypto/crc32": "3.0.0",
-                "@smithy/types": "^2.3.3",
-                "@smithy/util-hex-encoding": "^2.0.0",
-                "tslib": "^2.5.0"
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@smithy/fetch-http-handler": {
-            "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.1.5.tgz",
-            "integrity": "sha512-BIeCHGfr5JCGN+EMTwZK74ELvjPXOIrI7OLM5OhZJJ6AmZyRv2S9ANJk18AtLwht0TsSm+8WoXIEp8LuxNgUyA==",
+            "version": "5.3.17",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.17.tgz",
+            "integrity": "sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@smithy/protocol-http": "^3.0.5",
-                "@smithy/querystring-builder": "^2.0.9",
-                "@smithy/types": "^2.3.3",
-                "@smithy/util-base64": "^2.0.0",
-                "tslib": "^2.5.0"
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/querystring-builder": "^4.2.14",
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-base64": "^4.3.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@smithy/hash-node": {
-            "version": "2.0.9",
-            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.9.tgz",
-            "integrity": "sha512-XP3yWd5wyCtiVmsY5Nuq/FUwyCEQ6YG7DsvRh7ThldNukGpCzyFdP8eivZJVjn4Fx7oYrrOnVoYZ0WEgpW1AvQ==",
+            "version": "4.2.14",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.14.tgz",
+            "integrity": "sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@smithy/types": "^2.3.3",
-                "@smithy/util-buffer-from": "^2.0.0",
-                "@smithy/util-utf8": "^2.0.0",
-                "tslib": "^2.5.0"
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-buffer-from": "^4.2.2",
+                "@smithy/util-utf8": "^4.2.2",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@smithy/invalid-dependency": {
-            "version": "2.0.9",
-            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.9.tgz",
-            "integrity": "sha512-RuJqhYf8nViK96IIO9JbTtjDUuFItVfuuJhWw2yk7fv67yltQ7fZD6IQ2OsHHluoVmstnQJuCg5raXJR696Ubw==",
+            "version": "4.2.14",
+            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.14.tgz",
+            "integrity": "sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@smithy/types": "^2.3.3",
-                "tslib": "^2.5.0"
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@smithy/is-array-buffer": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
-            "integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+            "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "tslib": "^2.5.0"
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@smithy/middleware-content-length": {
-            "version": "2.0.11",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.11.tgz",
-            "integrity": "sha512-Malj4voNTL4+a5ZL3a6+Ij7JTUMTa2R7c3ZIBzMxN5OUUgAspU7uFi1Q97f4B0afVh2joQBAWH5IQJUG25nl8g==",
+            "version": "4.2.14",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.14.tgz",
+            "integrity": "sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@smithy/protocol-http": "^3.0.5",
-                "@smithy/types": "^2.3.3",
-                "tslib": "^2.5.0"
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@smithy/middleware-endpoint": {
-            "version": "2.0.9",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.0.9.tgz",
-            "integrity": "sha512-72/o8R6AAO4+nyTI6h4z6PYGTSA4dr1M7tZz29U8DEUHuh1YkhC77js0P6RyF9G0wDLuYqxb+Yh0crI5WG2pJg==",
+            "version": "4.4.32",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.32.tgz",
+            "integrity": "sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@smithy/middleware-serde": "^2.0.9",
-                "@smithy/types": "^2.3.3",
-                "@smithy/url-parser": "^2.0.9",
-                "@smithy/util-middleware": "^2.0.2",
-                "tslib": "^2.5.0"
+                "@smithy/core": "^3.23.17",
+                "@smithy/middleware-serde": "^4.2.20",
+                "@smithy/node-config-provider": "^4.3.14",
+                "@smithy/shared-ini-file-loader": "^4.4.9",
+                "@smithy/types": "^4.14.1",
+                "@smithy/url-parser": "^4.2.14",
+                "@smithy/util-middleware": "^4.2.14",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@smithy/middleware-retry": {
-            "version": "2.0.12",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.12.tgz",
-            "integrity": "sha512-YQ/ufXX4/d9/+Jf1QQ4J+CVeupC7BW52qldBTvRV33PDX9vxndlAwkFwzBcmnUFC3Hjf1//HW6I77EItcjNSCA==",
+            "version": "4.5.7",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.7.tgz",
+            "integrity": "sha512-bRt6ZImqVSeTk39Nm81K20ObIiAZ3WefY7G6+iz/0tZjs4dgRRjvRX2sgsH+zi6iDCRR/aQvQofLKxxz4rPBZg==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@smithy/node-config-provider": "^2.0.12",
-                "@smithy/protocol-http": "^3.0.5",
-                "@smithy/service-error-classification": "^2.0.2",
-                "@smithy/types": "^2.3.3",
-                "@smithy/util-middleware": "^2.0.2",
-                "@smithy/util-retry": "^2.0.2",
-                "tslib": "^2.5.0",
-                "uuid": "^8.3.2"
+                "@smithy/core": "^3.23.17",
+                "@smithy/node-config-provider": "^4.3.14",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/service-error-classification": "^4.3.1",
+                "@smithy/smithy-client": "^4.12.13",
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-middleware": "^4.2.14",
+                "@smithy/util-retry": "^4.3.6",
+                "@smithy/uuid": "^1.1.2",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@smithy/middleware-serde": {
-            "version": "2.0.9",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.9.tgz",
-            "integrity": "sha512-GVbauxrr6WmtCaesakktg3t5LR/yDbajpC7KkWc8rtCpddMI4ShAVO5Q6DqwX8MDFi4CLaY8H7eTGcxhl3jbLg==",
+            "version": "4.2.20",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.20.tgz",
+            "integrity": "sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@smithy/types": "^2.3.3",
-                "tslib": "^2.5.0"
+                "@smithy/core": "^3.23.17",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@smithy/middleware-stack": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.3.tgz",
-            "integrity": "sha512-AlhPmbwpkC4lQBVaVHXczmjFvsAhDHhrakqLt038qFLotnJcvDLhmMzAtu23alBeOSkKxkTQq0LsAt2N0WpAbw==",
+            "version": "4.2.14",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.14.tgz",
+            "integrity": "sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@smithy/types": "^2.3.3",
-                "tslib": "^2.5.0"
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@smithy/node-config-provider": {
-            "version": "2.0.12",
-            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.0.12.tgz",
-            "integrity": "sha512-df9y9ywv+JmS40Y60ZqJ4jfZiTCmyHQffwzIqjBjLJLJl0imf9F6DWBd+jiEWHvlohR+sFhyY+KL/qzKgnAq1A==",
+            "version": "4.3.14",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.14.tgz",
+            "integrity": "sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@smithy/property-provider": "^2.0.10",
-                "@smithy/shared-ini-file-loader": "^2.0.11",
-                "@smithy/types": "^2.3.3",
-                "tslib": "^2.5.0"
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/shared-ini-file-loader": "^4.4.9",
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@smithy/node-http-handler": {
-            "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.1.5.tgz",
-            "integrity": "sha512-52uF+BrZaFiBh+NT/bADiVDCQO91T+OwDRsuaAeWZC1mlCXFjAPPQdxeQohtuYOe9m7mPP/xIMNiqbe8jvndHA==",
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.6.1.tgz",
+            "integrity": "sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@smithy/abort-controller": "^2.0.9",
-                "@smithy/protocol-http": "^3.0.5",
-                "@smithy/querystring-builder": "^2.0.9",
-                "@smithy/types": "^2.3.3",
-                "tslib": "^2.5.0"
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/querystring-builder": "^4.2.14",
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@smithy/property-provider": {
-            "version": "2.0.10",
-            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.10.tgz",
-            "integrity": "sha512-YMBVfh0ZMmJtbsUn+WfSwR32iRljZPdRN0Tn2GAcdJ+ejX8WrBXD7Z0jIkQDrQZr8fEuuv5x8WxMIj+qVbsPQw==",
+            "version": "4.2.14",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.14.tgz",
+            "integrity": "sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@smithy/types": "^2.3.3",
-                "tslib": "^2.5.0"
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@smithy/protocol-http": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.5.tgz",
-            "integrity": "sha512-3t3fxj+ip4EPHRC2fQ0JimMxR/qCQ1LSQJjZZVZFgROnFLYWPDgUZqpoi7chr+EzatxJVXF/Rtoi5yLHOWCoZQ==",
+            "version": "5.3.14",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
+            "integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@smithy/types": "^2.3.3",
-                "tslib": "^2.5.0"
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@smithy/querystring-builder": {
-            "version": "2.0.9",
-            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.9.tgz",
-            "integrity": "sha512-Yt6CPF4j3j1cuwod/DRflbuXxBFjJm7gAjy6W1RE21Rz5/kfGFqiZBXWmmXwGtnnhiLThYwoHK4S6/TQtnx0Fg==",
+            "version": "4.2.14",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.14.tgz",
+            "integrity": "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@smithy/types": "^2.3.3",
-                "@smithy/util-uri-escape": "^2.0.0",
-                "tslib": "^2.5.0"
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-uri-escape": "^4.2.2",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@smithy/querystring-parser": {
-            "version": "2.0.9",
-            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.9.tgz",
-            "integrity": "sha512-U6z4N743s4vrcxPW8p8+reLV0PjMCYEyb1/wtMVvv3VnbJ74gshdI8SR1sBnEh95cF8TxonmX5IxY25tS9qGfg==",
+            "version": "4.2.14",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.14.tgz",
+            "integrity": "sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@smithy/types": "^2.3.3",
-                "tslib": "^2.5.0"
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@smithy/service-error-classification": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.2.tgz",
-            "integrity": "sha512-GTUd2j63gKy7A+ggvSdn2hc4sejG7LWfE+ZMF17vzWoNyqERWbRP7HTPS0d0Lwg1p6OQCAzvNigSrEIWVFt6iA==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.3.1.tgz",
+            "integrity": "sha512-aUQuDGh760ts/8MU+APjIZhlLPKhIIfqyzZaJikLEIMrdxFvxuLYD0WxWzaYWpmLbQlXDe9p7EWM3HsBe0K6Gw==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@smithy/types": "^2.3.3"
+                "@smithy/types": "^4.14.1"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@smithy/shared-ini-file-loader": {
-            "version": "2.0.11",
-            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.0.11.tgz",
-            "integrity": "sha512-Sf0u5C5px6eykXi6jImDTp+edvG3REtPjXnFWU/J+b7S2wkXwUqFXqBL5DdM4zC1F+M8u57ZT7NRqDwMOw7/Tw==",
+            "version": "4.4.9",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.9.tgz",
+            "integrity": "sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@smithy/types": "^2.3.3",
-                "tslib": "^2.5.0"
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@smithy/signature-v4": {
-            "version": "2.0.9",
-            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.9.tgz",
-            "integrity": "sha512-RkHP0joSI1j2EI+mU55sOi33/aMMkKdL9ZY+SWrPxsiCe1oyzzuy79Tpn8X7uT+t0ilNmQlwPpkP/jUy940pEA==",
+            "version": "5.3.14",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.14.tgz",
+            "integrity": "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@smithy/eventstream-codec": "^2.0.9",
-                "@smithy/is-array-buffer": "^2.0.0",
-                "@smithy/types": "^2.3.3",
-                "@smithy/util-hex-encoding": "^2.0.0",
-                "@smithy/util-middleware": "^2.0.2",
-                "@smithy/util-uri-escape": "^2.0.0",
-                "@smithy/util-utf8": "^2.0.0",
-                "tslib": "^2.5.0"
+                "@smithy/is-array-buffer": "^4.2.2",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-hex-encoding": "^4.2.2",
+                "@smithy/util-middleware": "^4.2.14",
+                "@smithy/util-uri-escape": "^4.2.2",
+                "@smithy/util-utf8": "^4.2.2",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@smithy/smithy-client": {
-            "version": "2.1.7",
-            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.1.7.tgz",
-            "integrity": "sha512-r6T/oiBQ8vCbGqObH4/h0YqD0jFB1hAS9KFRmuTfaNJueu/L2hjmjqFjv3PV5lkbNHTgUYraSv4cFQ1naxiELQ==",
+            "version": "4.12.13",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.13.tgz",
+            "integrity": "sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@smithy/middleware-stack": "^2.0.3",
-                "@smithy/types": "^2.3.3",
-                "@smithy/util-stream": "^2.0.12",
-                "tslib": "^2.5.0"
+                "@smithy/core": "^3.23.17",
+                "@smithy/middleware-endpoint": "^4.4.32",
+                "@smithy/middleware-stack": "^4.2.14",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-stream": "^4.5.25",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@smithy/types": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.3.3.tgz",
-            "integrity": "sha512-zTdIPR9PvFVNRdIKMQu4M5oyTaycIbUqLheQqaOi9rTWPkgjGO2wDBxMA1rBHQB81aqAEv+DbSS4jfKyQMnXRA==",
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
+            "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "tslib": "^2.5.0"
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@smithy/url-parser": {
-            "version": "2.0.9",
-            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.9.tgz",
-            "integrity": "sha512-NBnJ0NiY8z6E82Xd5VYUFQfKwK/wA/+QkKmpYUYP+cpH3aCzE6g2gvixd9vQKYjsIdRfNPCf+SFAozt8ljozOw==",
+            "version": "4.2.14",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.14.tgz",
+            "integrity": "sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@smithy/querystring-parser": "^2.0.9",
-                "@smithy/types": "^2.3.3",
-                "tslib": "^2.5.0"
+                "@smithy/querystring-parser": "^4.2.14",
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@smithy/util-base64": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.0.0.tgz",
-            "integrity": "sha512-Zb1E4xx+m5Lud8bbeYi5FkcMJMnn+1WUnJF3qD7rAdXpaL7UjkFQLdmW5fHadoKbdHpwH9vSR8EyTJFHJs++tA==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+            "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@smithy/util-buffer-from": "^2.0.0",
-                "tslib": "^2.5.0"
+                "@smithy/util-buffer-from": "^4.2.2",
+                "@smithy/util-utf8": "^4.2.2",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@smithy/util-body-length-browser": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.0.0.tgz",
-            "integrity": "sha512-JdDuS4ircJt+FDnaQj88TzZY3+njZ6O+D3uakS32f2VNnDo3vyEuNdBOh/oFd8Df1zSZOuH1HEChk2AOYDezZg==",
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
+            "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "tslib": "^2.5.0"
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@smithy/util-body-length-node": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.1.0.tgz",
-            "integrity": "sha512-/li0/kj/y3fQ3vyzn36NTLGmUwAICb7Jbe/CsWCktW363gh1MOcpEcSO3mJ344Gv2dqz8YJCLQpb6hju/0qOWw==",
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
+            "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "tslib": "^2.5.0"
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@smithy/util-buffer-from": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
-            "integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+            "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@smithy/is-array-buffer": "^2.0.0",
-                "tslib": "^2.5.0"
+                "@smithy/is-array-buffer": "^4.2.2",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@smithy/util-config-provider": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.0.0.tgz",
-            "integrity": "sha512-xCQ6UapcIWKxXHEU4Mcs2s7LcFQRiU3XEluM2WcCjjBtQkUN71Tb+ydGmJFPxMUrW/GWMgQEEGipLym4XG0jZg==",
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
+            "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "tslib": "^2.5.0"
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@smithy/util-defaults-mode-browser": {
-            "version": "2.0.11",
-            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.11.tgz",
-            "integrity": "sha512-0syV1Mz/mCQ7CG/MHKQfH+w86xq59jpD0EOXv5oe0WBXLmq2lWPpVHl2Y6+jQ+/9fYzyZ5NF+NC/WEIuiv690A==",
+            "version": "4.3.49",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.49.tgz",
+            "integrity": "sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@smithy/property-provider": "^2.0.10",
-                "@smithy/smithy-client": "^2.1.7",
-                "@smithy/types": "^2.3.3",
-                "bowser": "^2.11.0",
-                "tslib": "^2.5.0"
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/smithy-client": "^4.12.13",
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">= 10.0.0"
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@smithy/util-defaults-mode-node": {
-            "version": "2.0.13",
-            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.13.tgz",
-            "integrity": "sha512-6BtCHYdw5Z8r6KpW8tRCc3yURgvcQwfIEeHhR70BeSOfx8T/TXPPjb8A+K45+KASspa3fzrsSxeIwB0sAeMoHA==",
+            "version": "4.2.54",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.54.tgz",
+            "integrity": "sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@smithy/config-resolver": "^2.0.10",
-                "@smithy/credential-provider-imds": "^2.0.12",
-                "@smithy/node-config-provider": "^2.0.12",
-                "@smithy/property-provider": "^2.0.10",
-                "@smithy/smithy-client": "^2.1.7",
-                "@smithy/types": "^2.3.3",
-                "tslib": "^2.5.0"
+                "@smithy/config-resolver": "^4.4.17",
+                "@smithy/credential-provider-imds": "^4.2.14",
+                "@smithy/node-config-provider": "^4.3.14",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/smithy-client": "^4.12.13",
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">= 10.0.0"
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-endpoints": {
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.4.2.tgz",
+            "integrity": "sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.3.14",
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@smithy/util-hex-encoding": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
-            "integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+            "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "tslib": "^2.5.0"
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@smithy/util-middleware": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.2.tgz",
-            "integrity": "sha512-UGPZM+Ja/vke5pc/S8G0LNiHpVirtjppsXO+GK9m9wbzRGzPJTfnZA/gERUUN/AfxEy/8SL7U1kd7u4t2X8K1w==",
+            "version": "4.2.14",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.14.tgz",
+            "integrity": "sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@smithy/types": "^2.3.3",
-                "tslib": "^2.5.0"
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@smithy/util-retry": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.2.tgz",
-            "integrity": "sha512-ovWiayUB38moZcLhSFFfUgB2IMb7R1JfojU20qSahjxAgfOZvDWme3eOYUMtAVnouZ9kYJiFgHLy27qRH4NeeA==",
+            "version": "4.3.6",
+            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.6.tgz",
+            "integrity": "sha512-p6/FO1n2KxMeQyna067i0uJ6TSbb165ZhnRtCpWh4Foxqbfc6oW+XITaL8QkFJj3KFnDe2URt4gOhgU06EP9ew==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@smithy/service-error-classification": "^2.0.2",
-                "@smithy/types": "^2.3.3",
-                "tslib": "^2.5.0"
+                "@smithy/service-error-classification": "^4.3.1",
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">= 14.0.0"
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@smithy/util-stream": {
-            "version": "2.0.12",
-            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.12.tgz",
-            "integrity": "sha512-FOCpRLaj6gvSyUC5mJAACT+sPMPmp9sD1o+hVbUH/QxwZfulypA3ZIFdAg/59/IY0d/1Q4CTztsiHEB5LgjN4g==",
+            "version": "4.5.25",
+            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.25.tgz",
+            "integrity": "sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@smithy/fetch-http-handler": "^2.1.5",
-                "@smithy/node-http-handler": "^2.1.5",
-                "@smithy/types": "^2.3.3",
-                "@smithy/util-base64": "^2.0.0",
-                "@smithy/util-buffer-from": "^2.0.0",
-                "@smithy/util-hex-encoding": "^2.0.0",
-                "@smithy/util-utf8": "^2.0.0",
-                "tslib": "^2.5.0"
+                "@smithy/fetch-http-handler": "^5.3.17",
+                "@smithy/node-http-handler": "^4.6.1",
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-base64": "^4.3.2",
+                "@smithy/util-buffer-from": "^4.2.2",
+                "@smithy/util-hex-encoding": "^4.2.2",
+                "@smithy/util-utf8": "^4.2.2",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@smithy/util-uri-escape": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.0.0.tgz",
-            "integrity": "sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==",
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+            "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "tslib": "^2.5.0"
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@smithy/util-utf8": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.0.tgz",
-            "integrity": "sha512-rctU1VkziY84n5OXe3bPNpKR001ZCME2JCaBBFgtiM2hfKbHFudc/BkMuPab8hRbLd0j3vbnBTTZ1igBf0wgiQ==",
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+            "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@smithy/util-buffer-from": "^2.0.0",
-                "tslib": "^2.5.0"
+                "@smithy/util-buffer-from": "^4.2.2",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@smithy/util-waiter": {
-            "version": "2.0.9",
-            "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.0.9.tgz",
-            "integrity": "sha512-Hy9Cs0FtIacC1aVFk98bm/7CYqim9fnHAPRnV/SB2mj02ExYs/9Dn5SrNQmtTBTLCn65KqYnNVBNS8GuGpZOOw==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.3.0.tgz",
+            "integrity": "sha512-JyjYmLAfS+pdxF92o4yLgEoy0zhayKTw73FU1aofLWwLcJw7iSqIY2exGmMTrl/lmZugP5p/zxdFSippJDfKWA==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@smithy/abort-controller": "^2.0.9",
-                "@smithy/types": "^2.3.3",
-                "tslib": "^2.5.0"
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/uuid": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+            "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@szmarczak/http-timer": {
@@ -4356,10 +4618,11 @@
             "dev": true
         },
         "node_modules/bowser": {
-            "version": "2.11.0",
-            "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+            "version": "2.14.1",
+            "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+            "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
             "dev": true,
+            "license": "MIT",
             "peer": true
         },
         "node_modules/brace-expansion": {
@@ -7181,24 +7444,41 @@
             "dev": true,
             "peer": true
         },
-        "node_modules/fast-xml-parser": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
-            "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
+        "node_modules/fast-xml-builder": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+            "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
             "dev": true,
             "funding": [
-                {
-                    "type": "paypal",
-                    "url": "https://paypal.me/naturalintelligence"
-                },
                 {
                     "type": "github",
                     "url": "https://github.com/sponsors/NaturalIntelligence"
                 }
             ],
+            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "strnum": "^1.0.5"
+                "path-expression-matcher": "^1.1.3"
+            }
+        },
+        "node_modules/fast-xml-parser": {
+            "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
+            "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@nodable/entities": "^2.1.0",
+                "fast-xml-builder": "^1.1.5",
+                "path-expression-matcher": "^1.5.0",
+                "strnum": "^2.2.3"
             },
             "bin": {
                 "fxparser": "src/cli/cli.js"
@@ -11548,6 +11828,23 @@
                 "node": ">=8"
             }
         },
+        "node_modules/path-expression-matcher": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+            "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
         "node_modules/path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -13971,10 +14268,17 @@
             }
         },
         "node_modules/strnum": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-            "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+            "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
             "peer": true
         },
         "node_modules/strtok3": {

--- a/repos/fdbt-netex-output/package-lock.json
+++ b/repos/fdbt-netex-output/package-lock.json
@@ -1917,15 +1917,16 @@
             }
         },
         "node_modules/@serverless/platform-client": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/@serverless/platform-client/-/platform-client-4.4.0.tgz",
-            "integrity": "sha512-urL7SNefRqC2EOFDcpvm8fyn/06B5yXWneKpyGw7ylGt0Qr9JHZCB9TiUeTkIpPUNz0jTvKUaJ2+M/JNEiaVIA==",
+            "version": "4.5.1",
+            "resolved": "https://registry.npmjs.org/@serverless/platform-client/-/platform-client-4.5.1.tgz",
+            "integrity": "sha512-XltmO/029X76zi0LUFmhsnanhE2wnqH1xf+WBt5K8gumQA9LnrfwLgPxj+VA+mm6wQhy+PCp7H5SS0ZPu7F2Cw==",
             "dev": true,
+            "license": "ISC",
             "peer": true,
             "dependencies": {
                 "adm-zip": "^0.5.5",
                 "archiver": "^5.3.0",
-                "axios": "^0.21.1",
+                "axios": "^1.6.2",
                 "fast-glob": "^3.2.7",
                 "https-proxy-agent": "^5.0.0",
                 "ignore": "^5.1.8",
@@ -4091,13 +4092,34 @@
             }
         },
         "node_modules/axios": {
-            "version": "0.21.4",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-            "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+            "version": "1.15.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+            "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
             "dev": true,
+            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "follow-redirects": "^1.14.0"
+                "follow-redirects": "^1.15.11",
+                "form-data": "^4.0.5",
+                "proxy-from-env": "^2.1.0"
+            }
+        },
+        "node_modules/axios/node_modules/form-data": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "es-set-tostringtag": "^2.1.0",
+                "hasown": "^2.0.2",
+                "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/babel-jest": {
@@ -4597,6 +4619,19 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/call-bind-apply-helpers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/callsites": {
@@ -5904,6 +5939,20 @@
                 "node": ">=12"
             }
         },
+        "node_modules/dunder-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/duration": {
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/duration/-/duration-0.2.2.tgz",
@@ -6070,15 +6119,47 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/es-set-tostringtag": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
-            "integrity": "sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==",
-            "dev": true,
+        "node_modules/es-define-property": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-object-atoms": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "license": "MIT",
             "dependencies": {
-                "get-intrinsic": "^1.1.3",
-                "has": "^1.0.3",
-                "has-tostringtag": "^1.0.0"
+                "es-errors": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-set-tostringtag": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+            "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.6",
+                "has-tostringtag": "^1.0.2",
+                "hasown": "^2.0.2"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -7333,9 +7414,9 @@
             "dev": true
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.3",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-            "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
             "dev": true,
             "funding": [
                 {
@@ -7343,6 +7424,7 @@
                     "url": "https://github.com/sponsors/RubenVerborgh"
                 }
             ],
+            "license": "MIT",
             "peer": true,
             "engines": {
                 "node": ">=4.0"
@@ -7544,9 +7626,13 @@
             }
         },
         "node_modules/function-bind": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
         },
         "node_modules/function.prototype.name": {
             "version": "1.1.6",
@@ -7608,14 +7694,24 @@
             }
         },
         "node_modules/get-intrinsic": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
-            "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+            "license": "MIT",
             "dependencies": {
-                "function-bind": "^1.1.1",
-                "has": "^1.0.3",
-                "has-proto": "^1.0.1",
-                "has-symbols": "^1.0.3"
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.1",
+                "function-bind": "^1.1.2",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "math-intrinsics": "^1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -7634,6 +7730,19 @@
             "dev": true,
             "engines": {
                 "node": ">=8.0.0"
+            }
+        },
+        "node_modules/get-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "license": "MIT",
+            "dependencies": {
+                "dunder-proto": "^1.0.1",
+                "es-object-atoms": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/get-stdin": {
@@ -7787,11 +7896,12 @@
             }
         },
         "node_modules/gopd": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-            "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-            "dependencies": {
-                "get-intrinsic": "^1.1.3"
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -7849,6 +7959,7 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
             "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+            "dev": true,
             "dependencies": {
                 "function-bind": "^1.1.1"
             },
@@ -7890,6 +8001,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
             "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+            "dev": true,
             "engines": {
                 "node": ">= 0.4"
             },
@@ -7898,9 +8010,10 @@
             }
         },
         "node_modules/has-symbols": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-            "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -7909,11 +8022,12 @@
             }
         },
         "node_modules/has-tostringtag": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-            "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+            "license": "MIT",
             "dependencies": {
-                "has-symbols": "^1.0.2"
+                "has-symbols": "^1.0.3"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -7983,6 +8097,18 @@
             },
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/hasown": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+            "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+            "license": "MIT",
+            "dependencies": {
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/hexoid": {
@@ -10264,6 +10390,15 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/math-intrinsics": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/memoizee": {
             "version": "0.4.15",
             "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.15.tgz",
@@ -11682,6 +11817,17 @@
             },
             "engines": {
                 "node": ">= 6"
+            }
+        },
+        "node_modules/proxy-from-env": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+            "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/psl": {

--- a/repos/fdbt-netex-output/src/netex-validator/package-lock.json
+++ b/repos/fdbt-netex-output/src/netex-validator/package-lock.json
@@ -4,16 +4,6 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
-        "2-thenable": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/2-thenable/-/2-thenable-1.0.0.tgz",
-            "integrity": "sha512-HqiDzaLDFCXkcCO/SwoyhRwqYtINFHF7t9BDRq4x90TOKNAJpiqUt9X5lQ08bwxYzc067HUywDjGySpebHcUpw==",
-            "dev": true,
-            "requires": {
-                "d": "1",
-                "es5-ext": "^0.10.47"
-            }
-        },
         "@iarna/toml": {
             "version": "2.2.5",
             "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
@@ -141,14 +131,14 @@
             }
         },
         "@serverless/platform-client": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/@serverless/platform-client/-/platform-client-4.3.2.tgz",
-            "integrity": "sha512-DAa5Z0JAZc6UfrTZLYwqoZxgAponZpFwaqd7WzzMA+loMCkYWyJNwxrAmV6cr2UUJpkko4toPZuJ3vM9Ie+NDA==",
+            "version": "4.5.1",
+            "resolved": "https://registry.npmjs.org/@serverless/platform-client/-/platform-client-4.5.1.tgz",
+            "integrity": "sha512-XltmO/029X76zi0LUFmhsnanhE2wnqH1xf+WBt5K8gumQA9LnrfwLgPxj+VA+mm6wQhy+PCp7H5SS0ZPu7F2Cw==",
             "dev": true,
             "requires": {
                 "adm-zip": "^0.5.5",
                 "archiver": "^5.3.0",
-                "axios": "^0.21.1",
+                "axios": "^1.6.2",
                 "fast-glob": "^3.2.7",
                 "https-proxy-agent": "^5.0.0",
                 "ignore": "^5.1.8",
@@ -301,6 +291,16 @@
             "dev": true,
             "requires": {
                 "@types/node": "*"
+            }
+        },
+        "2-thenable": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/2-thenable/-/2-thenable-1.0.0.tgz",
+            "integrity": "sha512-HqiDzaLDFCXkcCO/SwoyhRwqYtINFHF7t9BDRq4x90TOKNAJpiqUt9X5lQ08bwxYzc067HUywDjGySpebHcUpw==",
+            "dev": true,
+            "requires": {
+                "d": "1",
+                "es5-ext": "^0.10.47"
             }
         },
         "adm-zip": {
@@ -535,12 +535,14 @@
             }
         },
         "axios": {
-            "version": "0.21.4",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-            "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+            "version": "1.15.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+            "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
             "dev": true,
             "requires": {
-                "follow-redirects": "^1.14.0"
+                "follow-redirects": "^1.15.11",
+                "form-data": "^4.0.5",
+                "proxy-from-env": "^2.1.0"
             }
         },
         "balanced-match": {
@@ -703,6 +705,16 @@
             "requires": {
                 "function-bind": "^1.1.1",
                 "get-intrinsic": "^1.0.2"
+            }
+        },
+        "call-bind-apply-helpers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+            "dev": true,
+            "requires": {
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2"
             }
         },
         "camelcase": {
@@ -1312,6 +1324,17 @@
             "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
             "dev": true
         },
+        "dunder-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "dev": true,
+            "requires": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.2.0"
+            }
+        },
         "duration": {
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/duration/-/duration-0.2.2.tgz",
@@ -1365,6 +1388,39 @@
                 "string.prototype.trimend": "^1.0.5",
                 "string.prototype.trimstart": "^1.0.5",
                 "unbox-primitive": "^1.0.2"
+            }
+        },
+        "es-define-property": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+            "dev": true
+        },
+        "es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "dev": true
+        },
+        "es-object-atoms": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "dev": true,
+            "requires": {
+                "es-errors": "^1.3.0"
+            }
+        },
+        "es-set-tostringtag": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+            "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+            "dev": true,
+            "requires": {
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.6",
+                "has-tostringtag": "^1.0.2",
+                "hasown": "^2.0.2"
             }
         },
         "es-to-primitive": {
@@ -1649,9 +1705,9 @@
             "dev": true
         },
         "follow-redirects": {
-            "version": "1.15.1",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
-            "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
             "dev": true
         },
         "for-each": {
@@ -1664,13 +1720,15 @@
             }
         },
         "form-data": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-            "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
             "dev": true,
             "requires": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
+                "es-set-tostringtag": "^2.1.0",
+                "hasown": "^2.0.2",
                 "mime-types": "^2.1.12"
             }
         },
@@ -1747,9 +1805,9 @@
             "optional": true
         },
         "function-bind": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
             "dev": true
         },
         "function.prototype.name": {
@@ -1776,14 +1834,31 @@
             "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
         },
         "get-intrinsic": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
-            "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
             "dev": true,
             "requires": {
-                "function-bind": "^1.1.1",
-                "has": "^1.0.3",
-                "has-symbols": "^1.0.3"
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.1",
+                "function-bind": "^1.1.2",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "math-intrinsics": "^1.1.0"
+            }
+        },
+        "get-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "dev": true,
+            "requires": {
+                "dunder-proto": "^1.0.1",
+                "es-object-atoms": "^1.0.0"
             }
         },
         "get-stdin": {
@@ -1853,6 +1928,12 @@
                 "slash": "^3.0.0"
             }
         },
+        "gopd": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+            "dev": true
+        },
         "got": {
             "version": "11.8.5",
             "resolved": "https://registry.npmjs.org/got/-/got-11.8.5.tgz",
@@ -1917,18 +1998,27 @@
             }
         },
         "has-symbols": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-            "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
             "dev": true
         },
         "has-tostringtag": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-            "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
             "dev": true,
             "requires": {
-                "has-symbols": "^1.0.2"
+                "has-symbols": "^1.0.3"
+            }
+        },
+        "hasown": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+            "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+            "dev": true,
+            "requires": {
+                "function-bind": "^1.1.2"
             }
         },
         "hexoid": {
@@ -2282,7 +2372,8 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
             "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "jmespath": {
             "version": "0.16.0",
@@ -2556,6 +2647,12 @@
                     "dev": true
                 }
             }
+        },
+        "math-intrinsics": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+            "dev": true
         },
         "memoizee": {
             "version": "0.4.15",
@@ -2998,6 +3095,12 @@
             "version": "2.2.5",
             "resolved": "https://registry.npmjs.org/promise-queue/-/promise-queue-2.2.5.tgz",
             "integrity": "sha512-p/iXrPSVfnqPft24ZdNNLECw/UrtLTpT3jpAAMzl/o5/rDsGCPo3/CQS2611flL6LkoEJ3oQZw7C8Q80ZISXRQ==",
+            "dev": true
+        },
+        "proxy-from-env": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+            "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
             "dev": true
         },
         "pump": {
@@ -3543,6 +3646,14 @@
                 "is-stream": "^1.1.0"
             }
         },
+        "string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "requires": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
         "string-width": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
@@ -3573,14 +3684,6 @@
                 "call-bind": "^1.0.2",
                 "define-properties": "^1.1.4",
                 "es-abstract": "^1.19.5"
-            }
-        },
-        "string_decoder": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-            "requires": {
-                "safe-buffer": "~5.1.0"
             }
         },
         "strip-ansi": {
@@ -3999,7 +4102,8 @@
             "version": "7.5.9",
             "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
             "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "xml2js": {
             "version": "0.4.19",

--- a/repos/fdbt-reference-data-service/src/retrievers/package-lock.json
+++ b/repos/fdbt-reference-data-service/src/retrievers/package-lock.json
@@ -4,16 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "2-thenable": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/2-thenable/-/2-thenable-1.0.0.tgz",
-      "integrity": "sha512-HqiDzaLDFCXkcCO/SwoyhRwqYtINFHF7t9BDRq4x90TOKNAJpiqUt9X5lQ08bwxYzc067HUywDjGySpebHcUpw==",
-      "dev": true,
-      "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.47"
-      }
-    },
     "@colors/colors": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -333,14 +323,14 @@
       }
     },
     "@serverless/platform-client": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@serverless/platform-client/-/platform-client-4.3.2.tgz",
-      "integrity": "sha512-DAa5Z0JAZc6UfrTZLYwqoZxgAponZpFwaqd7WzzMA+loMCkYWyJNwxrAmV6cr2UUJpkko4toPZuJ3vM9Ie+NDA==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@serverless/platform-client/-/platform-client-4.5.1.tgz",
+      "integrity": "sha512-XltmO/029X76zi0LUFmhsnanhE2wnqH1xf+WBt5K8gumQA9LnrfwLgPxj+VA+mm6wQhy+PCp7H5SS0ZPu7F2Cw==",
       "dev": true,
       "requires": {
         "adm-zip": "^0.5.5",
         "archiver": "^5.3.0",
-        "axios": "^0.21.1",
+        "axios": "^1.6.2",
         "fast-glob": "^3.2.7",
         "https-proxy-agent": "^5.0.0",
         "ignore": "^5.1.8",
@@ -674,6 +664,16 @@
         "@types/node": "*"
       }
     },
+    "2-thenable": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/2-thenable/-/2-thenable-1.0.0.tgz",
+      "integrity": "sha512-HqiDzaLDFCXkcCO/SwoyhRwqYtINFHF7t9BDRq4x90TOKNAJpiqUt9X5lQ08bwxYzc067HUywDjGySpebHcUpw==",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.47"
+      }
+    },
     "adm-zip": {
       "version": "0.5.9",
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.9.tgz",
@@ -711,7 +711,8 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ansi-align": {
       "version": "3.0.1",
@@ -945,12 +946,14 @@
       }
     },
     "axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "dev": true,
       "requires": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "backo2": {
@@ -1230,6 +1233,16 @@
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
+      }
+    },
+    "call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "requires": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
       }
     },
     "camelcase": {
@@ -1965,6 +1978,17 @@
       "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
       "dev": true
     },
+    "dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "requires": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      }
+    },
     "duplexer3": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.5.tgz",
@@ -2068,7 +2092,8 @@
           "version": "7.4.6",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
           "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -2120,6 +2145,39 @@
         "string.prototype.trimend": "^1.0.5",
         "string.prototype.trimstart": "^1.0.5",
         "unbox-primitive": "^1.0.2"
+      }
+    },
+    "es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true
+    },
+    "es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true
+    },
+    "es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "requires": {
+        "es-errors": "^1.3.0"
+      }
+    },
+    "es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "requires": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       }
     },
     "es-to-primitive": {
@@ -2437,9 +2495,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
-      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "dev": true
     },
     "for-each": {
@@ -2452,13 +2510,15 @@
       }
     },
     "form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       }
     },
@@ -2537,9 +2597,9 @@
       "optional": true
     },
     "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "dev": true
     },
     "function.prototype.name": {
@@ -2625,14 +2685,31 @@
       "dev": true
     },
     "get-intrinsic": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
-      "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "dev": true,
       "requires": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.3"
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      }
+    },
+    "get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "requires": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
       }
     },
     "get-stdin": {
@@ -2713,6 +2790,12 @@
         "merge2": "^1.4.1",
         "slash": "^3.0.0"
       }
+    },
+    "gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true
     },
     "got": {
       "version": "11.8.5",
@@ -2906,18 +2989,18 @@
       }
     },
     "has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "dev": true
     },
     "has-tostringtag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
       "dev": true,
       "requires": {
-        "has-symbols": "^1.0.2"
+        "has-symbols": "^1.0.3"
       }
     },
     "has-unicode": {
@@ -2926,6 +3009,15 @@
       "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
       "dev": true,
       "optional": true
+    },
+    "hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.2"
+      }
     },
     "hexoid": {
       "version": "1.0.0",
@@ -3295,7 +3387,8 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
       "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jmespath": {
       "version": "0.16.0",
@@ -3699,6 +3792,12 @@
           "dev": true
         }
       }
+    },
+    "math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true
     },
     "media-typer": {
       "version": "0.3.0",
@@ -4354,6 +4453,12 @@
           "dev": true
         }
       }
+    },
+    "proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "dev": true
     },
     "pump": {
       "version": "3.0.0",
@@ -5227,6 +5332,15 @@
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
       "dev": true
     },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "string-width": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
@@ -5258,15 +5372,6 @@
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
         "es-abstract": "^1.19.5"
-      }
-    },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {
@@ -6105,7 +6210,8 @@
       "version": "7.5.9",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
       "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "xml2js": {
       "version": "0.4.19",

--- a/repos/fdbt-reference-data-service/src/retrievers/requirements.txt
+++ b/repos/fdbt-reference-data-service/src/retrievers/requirements.txt
@@ -1,3 +1,3 @@
 PyMySQL==1.1.1
-Requests==2.32.2
+Requests==2.33.0
 urllib3>=1.25.4,<2

--- a/repos/fdbt-reference-data-service/src/uploaders/package-lock.json
+++ b/repos/fdbt-reference-data-service/src/uploaders/package-lock.json
@@ -4,16 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "2-thenable": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/2-thenable/-/2-thenable-1.0.0.tgz",
-      "integrity": "sha512-HqiDzaLDFCXkcCO/SwoyhRwqYtINFHF7t9BDRq4x90TOKNAJpiqUt9X5lQ08bwxYzc067HUywDjGySpebHcUpw==",
-      "dev": true,
-      "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.47"
-      }
-    },
     "@colors/colors": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -333,14 +323,14 @@
       }
     },
     "@serverless/platform-client": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@serverless/platform-client/-/platform-client-4.3.2.tgz",
-      "integrity": "sha512-DAa5Z0JAZc6UfrTZLYwqoZxgAponZpFwaqd7WzzMA+loMCkYWyJNwxrAmV6cr2UUJpkko4toPZuJ3vM9Ie+NDA==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@serverless/platform-client/-/platform-client-4.5.1.tgz",
+      "integrity": "sha512-XltmO/029X76zi0LUFmhsnanhE2wnqH1xf+WBt5K8gumQA9LnrfwLgPxj+VA+mm6wQhy+PCp7H5SS0ZPu7F2Cw==",
       "dev": true,
       "requires": {
         "adm-zip": "^0.5.5",
         "archiver": "^5.3.0",
-        "axios": "^0.21.1",
+        "axios": "^1.6.2",
         "fast-glob": "^3.2.7",
         "https-proxy-agent": "^5.0.0",
         "ignore": "^5.1.8",
@@ -674,6 +664,16 @@
         "@types/node": "*"
       }
     },
+    "2-thenable": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/2-thenable/-/2-thenable-1.0.0.tgz",
+      "integrity": "sha512-HqiDzaLDFCXkcCO/SwoyhRwqYtINFHF7t9BDRq4x90TOKNAJpiqUt9X5lQ08bwxYzc067HUywDjGySpebHcUpw==",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.47"
+      }
+    },
     "adm-zip": {
       "version": "0.5.9",
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.9.tgz",
@@ -711,7 +711,8 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ansi-align": {
       "version": "3.0.1",
@@ -945,12 +946,14 @@
       }
     },
     "axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "dev": true,
       "requires": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "backo2": {
@@ -1230,6 +1233,16 @@
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
+      }
+    },
+    "call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "requires": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
       }
     },
     "camelcase": {
@@ -1965,6 +1978,17 @@
       "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
       "dev": true
     },
+    "dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "requires": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      }
+    },
     "duplexer3": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.5.tgz",
@@ -2068,7 +2092,8 @@
           "version": "7.4.6",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
           "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -2120,6 +2145,39 @@
         "string.prototype.trimend": "^1.0.5",
         "string.prototype.trimstart": "^1.0.5",
         "unbox-primitive": "^1.0.2"
+      }
+    },
+    "es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true
+    },
+    "es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true
+    },
+    "es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "requires": {
+        "es-errors": "^1.3.0"
+      }
+    },
+    "es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "requires": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       }
     },
     "es-to-primitive": {
@@ -2437,9 +2495,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
-      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "dev": true
     },
     "for-each": {
@@ -2452,13 +2510,15 @@
       }
     },
     "form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       }
     },
@@ -2537,9 +2597,9 @@
       "optional": true
     },
     "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "dev": true
     },
     "function.prototype.name": {
@@ -2625,14 +2685,31 @@
       "dev": true
     },
     "get-intrinsic": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
-      "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "dev": true,
       "requires": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.3"
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      }
+    },
+    "get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "requires": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
       }
     },
     "get-stdin": {
@@ -2713,6 +2790,12 @@
         "merge2": "^1.4.1",
         "slash": "^3.0.0"
       }
+    },
+    "gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true
     },
     "got": {
       "version": "11.8.5",
@@ -2906,18 +2989,18 @@
       }
     },
     "has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "dev": true
     },
     "has-tostringtag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
       "dev": true,
       "requires": {
-        "has-symbols": "^1.0.2"
+        "has-symbols": "^1.0.3"
       }
     },
     "has-unicode": {
@@ -2926,6 +3009,15 @@
       "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
       "dev": true,
       "optional": true
+    },
+    "hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.2"
+      }
     },
     "hexoid": {
       "version": "1.0.0",
@@ -3295,7 +3387,8 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
       "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jmespath": {
       "version": "0.16.0",
@@ -3699,6 +3792,12 @@
           "dev": true
         }
       }
+    },
+    "math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true
     },
     "media-typer": {
       "version": "0.3.0",
@@ -4354,6 +4453,12 @@
           "dev": true
         }
       }
+    },
+    "proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "dev": true
     },
     "pump": {
       "version": "3.0.0",
@@ -5227,6 +5332,15 @@
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
       "dev": true
     },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "string-width": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
@@ -5258,15 +5372,6 @@
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
         "es-abstract": "^1.19.5"
-      }
-    },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {
@@ -6105,7 +6210,8 @@
       "version": "7.5.9",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
       "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "xml2js": {
       "version": "0.4.19",

--- a/repos/fdbt-reference-data-service/src/uploaders/requirements.test.txt
+++ b/repos/fdbt-reference-data-service/src/uploaders/requirements.test.txt
@@ -2,6 +2,6 @@ boto3==1.26.90
 botocore==1.29.90
 PyMySQL==1.1.1
 xmltodict==0.15.1
-pytest==7.4.0
+pytest==9.0.3
 moto==4.1.14
 urllib3>=1.25.4,<2

--- a/repos/fdbt-reference-data-service/src/uploaders/requirements.test.txt
+++ b/repos/fdbt-reference-data-service/src/uploaders/requirements.test.txt
@@ -1,7 +1,7 @@
 boto3==1.26.90
 botocore==1.29.90
 PyMySQL==1.1.1
-xmltodict==0.13.0
+xmltodict==0.15.1
 pytest==7.4.0
 moto==4.1.14
 urllib3>=1.25.4,<2

--- a/repos/fdbt-reference-data-service/src/uploaders/requirements.txt
+++ b/repos/fdbt-reference-data-service/src/uploaders/requirements.txt
@@ -1,5 +1,5 @@
 boto3==1.26.90
 botocore==1.29.90
 PyMySQL==1.1.1
-xmltodict==0.13.0
+xmltodict==0.15.1
 urllib3>=1.25.4,<2


### PR DESCRIPTION
## Description

- Requests Lib:

Increases value of requests library from 2.32.2 to 2.33.0. 
https://github.com/psf/requests/blob/main/HISTORY.md

There are no breaking changes indicated in release notes above

- xmltodict
https://github.com/martinblech/xmltodict/blob/master/CHANGELOG.md
No breaking changes in versions. (Minor version bump only as this is brought in to the ticket as scope creep)

- pytest

Testing lib only - no breaking changes that will effect 

- axios (transitive)
- fast-xml-parser (transitive)

## Testing instructions

This should be tested via the ticket previous that this will unblock and via regression