### PR TITLE
Allows aws cross account for DB call

### DIFF
--- a/fdbt-aws/cloudformation/service/eu-west-2/iam.yml
+++ b/fdbt-aws/cloudformation/service/eu-west-2/iam.yml
@@ -358,11 +358,13 @@ Resources:
                   - "s3:GetObjectVersion"
                 Resource:
                   - !Sub arn:aws:s3:::fdbt-csv-ref-data-${Stage}/*
+                  - "arn:aws:s3:::bods-1297-data-landing-zone/*"
               - Effect: Allow
                 Action:
                   - "s3:ListBucket"
                 Resource:
                   - !Sub arn:aws:s3:::fdbt-csv-ref-data-${Stage}
+                  - "arn:aws:s3:::bods-1297-data-landing-zone/*"
           PolicyName: allow-aurora-s3-access
 
   SlackLambdaRole:


### PR DESCRIPTION
## Description

This pull request updates the IAM policy in `fdbt-aws/cloudformation/service/eu-west-2/iam.yml` to grant additional S3 access. The main change is to allow access to a new S3 bucket for both object-level and bucket-level actions.

**IAM Policy Updates:**

* Added `"arn:aws:s3:::bods-1297-data-landing-zone/*"` to the list of resources for the `s3:GetObject` and `s3:GetObjectVersion` actions, enabling access to objects in the new S3 bucket.
* Added `"arn:aws:s3:::bods-1297-data-landing-zone/*"` to the list of resources for the `s3:ListBucket` action, allowing listing of the new S3 bucket.
