### PR TITLE
refactor: remove unused NPTG environment variables

### DIFF
--- a/repos/fdbt-reference-data-service/src/uploaders/serverless.yml
+++ b/repos/fdbt-reference-data-service/src/uploaders/serverless.yml
@@ -21,9 +21,6 @@ provider:
         NAPTAN_ROLE_ARN: ${env:NAPTAN_ROLE_ARN, ''}
         NAPTAN_BUCKET_REGION: ${env:NAPTAN_BUCKET_REGION, ''}
         CSV_BUCKET_NAME: ${env:CSV_BUCKET_NAME, ''}
-        NPTG_S3_KEY: ${env:NPTG_S3_KEY, ''}
-        NPTG_BUCKET_NAME: ${env:NPTG_BUCKET_NAME, ''}
-        NPTG_ROLE_ARN: ${env:NPTG_ROLE_ARN, ''}
     iam:
         role:
             statements:


### PR DESCRIPTION
## Description

This PR removes unused NPTG environment variables not listed in the ticket description for `eference-data-service-uploaders` service


## Testing instructions
Add testing instructions, if required
