### PR TITLE
fix: failing test in reference data service

### DIFF
--- a/fdbt-aws/cloudformation/service/eu-west-2/iam.yml
+++ b/fdbt-aws/cloudformation/service/eu-west-2/iam.yml
@@ -358,11 +358,13 @@ Resources:
                   - "s3:GetObjectVersion"
                 Resource:
                   - !Sub arn:aws:s3:::fdbt-csv-ref-data-${Stage}/*
+                  - "arn:aws:s3:::bods-1297-data-landing-zone/*"
               - Effect: Allow
                 Action:
                   - "s3:ListBucket"
                 Resource:
                   - !Sub arn:aws:s3:::fdbt-csv-ref-data-${Stage}
+                  - "arn:aws:s3:::bods-1297-data-landing-zone/*"
           PolicyName: allow-aurora-s3-access
 
   SlackLambdaRole:

--- a/repos/fdbt-reference-data-service/src/uploaders/tests/conftest.py
+++ b/repos/fdbt-reference-data-service/src/uploaders/tests/conftest.py
@@ -10,6 +10,8 @@ def aws_credentials():
     os.environ['AWS_SECRET_ACCESS_KEY'] = 'testing'
     os.environ['AWS_SECURITY_TOKEN'] = 'testing'
     os.environ['AWS_SESSION_TOKEN'] = 'testing'
+    os.environ['NAPTAN_S3_KEY'] = 'testing'
+    os.environ['NAPTAN_BUCKET_REGION'] = 'eu-west-2'
 
 @pytest.fixture(scope='function')
 def s3(aws_credentials):

--- a/repos/fdbt-reference-data-service/src/uploaders/tests/test_csv_uploader.py
+++ b/repos/fdbt-reference-data-service/src/uploaders/tests/test_csv_uploader.py
@@ -1,3 +1,4 @@
+import os
 from csv_uploader.db_queries import *
 
 
@@ -19,5 +20,7 @@ class TestClass:
 
     def test_stops_bucket_insertion(self):
         bucket = "unit-test-bucket"
-        result = stops_query(bucket)
+        naptan_s3_key = os.getenv("NAPTAN_S3_KEY", "testing")
+        naptan_bucket_region = os.getenv("NAPTAN_BUCKET_REGION", "eu-west-2")
+        result = stops_query(bucket, naptan_s3_key, naptan_bucket_region)
         assert result[3].__contains__(bucket)


### PR DESCRIPTION
## Description

Tests had failed due to the changes made for ticket DBODS-1293, which prevent the fdbt reference data service from going to test, see github flow below:
https://github.com/department-for-transport-BODS/create-data/actions/runs/26817091691/job/79061524851
Made updates to test that should allow this workflow to complete.
