### PR TITLE
Fix: DBODS-1629: Updating to read NOC data from S3 bucket

### DIFF
--- a/repos/fdbt-reference-data-service/src/retrievers/csv_retriever/main.py
+++ b/repos/fdbt-reference-data-service/src/retrievers/csv_retriever/main.py
@@ -145,7 +145,7 @@ def noc_handler(event, context):
             noc_s3_keys = stage_noc_file_locally(noc_bucket, noc_role_arn, noc_bucket_region, local_bucket)
             bucket = local_bucket
         else:
-            # List objects in the folder and select the 3 required CSVs directly
+            # List objects in the folder and select the 3 required CSVs directly.
             s3_client = boto3.client('s3', region_name=noc_bucket_region)
             response = s3_client.list_objects_v2(Bucket=noc_bucket, Prefix=noc_folder)
             all_keys = [obj['Key'] for obj in response.get('Contents', [])]
@@ -173,22 +173,11 @@ def noc_handler(event, context):
                     Key=target_filename,
                 )
                 noc_s3_keys.append(target_filename)
+
             bucket = noc_bucket
 
-        # Process each selected CSV
-        for noc_s3_key in noc_s3_keys:
-            logger.info(f"Running scheduled NOC upload from bucket: {bucket} for file: {noc_s3_key}")
-            insert_in_database(noc_s3_key, bucket, noc_bucket_region=noc_bucket_region)
-
-    except Exception as e:
-        ssm.put_parameter(
-            Name="/scheduled/disable-table-renamer",
-            Value="true",
-            Type="String",
-            Overwrite=True
-        )
-        logger.error(e)
-        raise e
+        logger.info(f"NOC CSVs uploaded to bucket: {bucket}")
+        logger.info(f"NOC files processed: {noc_s3_keys}")
 
 def lambda_handler(event, context):
     try:

--- a/repos/fdbt-reference-data-service/src/retrievers/csv_retriever/main.py
+++ b/repos/fdbt-reference-data-service/src/retrievers/csv_retriever/main.py
@@ -122,62 +122,26 @@ def stage_noc_file_locally(noc_bucket: str, role_arn: str, region: str, local_bu
     return staged_keys
 
 def noc_handler(event, context):
-    try:
-        noc_bucket = os.getenv("NOC_BUCKET_NAME")
-        if noc_bucket is None:
-            raise Exception("No NOC_BUCKET_NAME environment variable set")
+    noc_bucket = os.getenv("NOC_BUCKET_NAME")
+    if noc_bucket is None:
+        raise Exception("No NOC_BUCKET_NAME environment variable set")
 
-        noc_folder = os.getenv("NOC_S3_KEY")
-        if noc_folder is None:
-            raise Exception("No NOC_S3_KEY environment variable set")
+    role_arn = os.getenv("NOC_ROLE_ARN")
+    region = os.getenv("NOC_BUCKET_REGION")
 
-        noc_role_arn = os.getenv("NOC_ROLE_ARN")
-        noc_bucket_region = os.getenv("NOC_BUCKET_REGION")
+    if region is None:
+        raise Exception("No NOC_BUCKET_REGION environment variable set")
 
-        if noc_bucket_region is None:
-            raise Exception("No NOC_BUCKET_REGION environment variable set")
+    if role_arn:
+        local_bucket = os.getenv("NOC_CSV_BUCKET_NAME")
+        if local_bucket is None:
+            raise Exception("NOC_CSV_BUCKET_NAME environment variable must be set when NOC_ROLE_ARN is configured")
 
-        if noc_role_arn:
-            local_bucket = os.getenv("NOC_CSV_BUCKET_NAME")
-            if local_bucket is None:
-                raise Exception("NOC_CSV_BUCKET_NAME environment variable must be set when NOC_ROLE_ARN is configured")
+        bucket = stage_noc_file_locally(noc_bucket, role_arn, region, local_bucket)
+    else:
+        bucket = noc_bucket
 
-            noc_s3_keys = stage_noc_file_locally(noc_bucket, noc_role_arn, noc_bucket_region, local_bucket)
-            bucket = local_bucket
-        else:
-            # List objects in the folder and select the 3 required CSVs directly.
-            s3_client = boto3.client('s3', region_name=noc_bucket_region)
-            response = s3_client.list_objects_v2(Bucket=noc_bucket, Prefix=noc_folder)
-            all_keys = [obj['Key'] for obj in response.get('Contents', [])]
-            target_filenames = list(NOC_FILE_NAME_MAPPING.keys())
-            matched_noc_s3_keys = [
-                key for key in all_keys
-                if os.path.basename(key).lower() in target_filenames
-            ]
-            if len(matched_noc_s3_keys) != 3:
-                raise Exception(
-                    f"Expected 3 NOC CSVs (noclines, noctable, publicname) but found "
-                    f"{len(matched_noc_s3_keys)}: {matched_noc_s3_keys}"
-                )
-            noc_s3_keys = []
-            for source_key in matched_noc_s3_keys:
-                source_filename = os.path.basename(source_key).lower()
-                target_filename = NOC_FILE_NAME_MAPPING[source_filename]
-
-                logger.info(
-                    f"Copying s3://{noc_bucket}/{source_key} to s3://{noc_bucket}/{target_filename}"
-                )
-                s3_client.copy_object(
-                    Bucket=noc_bucket,
-                    CopySource={"Bucket": noc_bucket, "Key": source_key},
-                    Key=target_filename,
-                )
-                noc_s3_keys.append(target_filename)
-
-            bucket = noc_bucket
-
-        logger.info(f"NOC CSVs uploaded to bucket: {bucket}")
-        logger.info(f"NOC files processed: {noc_s3_keys}")
+    logger.info(f"NOC CSVs uploaded to bucket: {bucket}")
 
 def lambda_handler(event, context):
     try:

--- a/repos/fdbt-reference-data-service/src/retrievers/csv_retriever/main.py
+++ b/repos/fdbt-reference-data-service/src/retrievers/csv_retriever/main.py
@@ -69,6 +69,116 @@ def naptan_handler(event, context):
             bucket = naptan_bucket
 
         logger.info(f"NaPTAN uploaded to bucket: {bucket}")
+        
+NOC_FILE_NAME_MAPPING = {
+    "table_noclines_latest_csv.csv": "NOCLines.csv",
+    "table_noc_table_latest_csv.csv": "NOCTable.csv",
+    "table_noc_public_name_latest_csv.csv": "PublicName.csv",
+}
+
+def stage_noc_file_locally(noc_bucket: str, role_arn: str, region: str, local_bucket: str) -> list:
+    """List all files in the NOC folder prefix, select the 3 required CSVs (noclines, noctable,
+    publicname), download from the cross-account bucket and re-upload to the local bucket.
+    Returns the list of S3 keys that were staged."""
+    logger.info(f"Assuming role {role_arn} to read NOC CSVs from {noc_bucket}")
+    cross_account_client = get_cross_account_s3_client(role_arn, region)
+
+    noc_folder = os.getenv("NOC_S3_KEY")
+    noc_tmp_path = os.getenv("NOC_TMP_PATH")
+
+    if noc_folder is None or noc_tmp_path is None:
+        raise Exception("NOC_S3_KEY and NOC_TMP_PATH environment variables must be set")
+
+    # List all objects under the NOC folder prefix
+    logger.info(f"Listing objects in s3://{noc_bucket}/{noc_folder}")
+    response = cross_account_client.list_objects_v2(Bucket=noc_bucket, Prefix=noc_folder)
+    all_keys = [obj['Key'] for obj in response.get('Contents', [])]
+
+    # Select the 3 required CSVs by matching the expected source filenames.
+    target_filenames = list(NOC_FILE_NAME_MAPPING.keys())
+    selected_keys = [
+        key for key in all_keys
+        if os.path.basename(key).lower() in target_filenames
+    ]
+
+    if len(selected_keys) != 3:
+        raise Exception(
+            f"Expected 3 NOC CSVs (noclines, noctable, publicname) but found "
+            f"{len(selected_keys)}: {selected_keys}"
+        )
+
+    staged_keys = []
+    for key in selected_keys:
+        filename = os.path.basename(key).lower()
+        mapped_filename = NOC_FILE_NAME_MAPPING[filename]
+        tmp_file = os.path.join(noc_tmp_path, filename)
+        logger.info(f"Downloading s3://{noc_bucket}/{key} to {tmp_file}")
+        cross_account_client.download_file(noc_bucket, key, tmp_file)
+
+        logger.info(f"Uploading NOC CSV to local bucket s3://{local_bucket}/{mapped_filename}")
+        s3.Bucket(local_bucket).upload_file(tmp_file, mapped_filename)
+        staged_keys.append(mapped_filename)
+
+    return staged_keys
+
+def noc_handler(event, context):
+    try:
+        noc_bucket = os.getenv("NOC_BUCKET_NAME")
+        if noc_bucket is None:
+            raise Exception("No NOC_BUCKET_NAME environment variable set")
+
+        noc_folder = os.getenv("NOC_S3_KEY")
+        if noc_folder is None:
+            raise Exception("No NOC_S3_KEY environment variable set")
+
+        noc_role_arn = os.getenv("NOC_ROLE_ARN")
+        noc_bucket_region = os.getenv("NOC_BUCKET_REGION")
+
+        if noc_bucket_region is None:
+            raise Exception("No NOC_BUCKET_REGION environment variable set")
+
+        if noc_role_arn:
+            local_bucket = os.getenv("NOC_CSV_BUCKET_NAME")
+            if local_bucket is None:
+                raise Exception("NOC_CSV_BUCKET_NAME environment variable must be set when NOC_ROLE_ARN is configured")
+
+            noc_s3_keys = stage_noc_file_locally(noc_bucket, noc_role_arn, noc_bucket_region, local_bucket)
+            bucket = local_bucket
+        else:
+            # List objects in the folder and select the 3 required CSVs directly
+            s3_client = boto3.client('s3', region_name=noc_bucket_region)
+            response = s3_client.list_objects_v2(Bucket=noc_bucket, Prefix=noc_folder)
+            all_keys = [obj['Key'] for obj in response.get('Contents', [])]
+            target_filenames = list(NOC_FILE_NAME_MAPPING.keys())
+            matched_noc_s3_keys = [
+                key for key in all_keys
+                if os.path.basename(key).lower() in target_filenames
+            ]
+            if len(matched_noc_s3_keys) != 3:
+                raise Exception(
+                    f"Expected 3 NOC CSVs (noclines, noctable, publicname) but found "
+                    f"{len(matched_noc_s3_keys)}: {matched_noc_s3_keys}"
+                )
+            noc_s3_keys = []
+            for source_key in matched_noc_s3_keys:
+                source_filename = os.path.basename(source_key).lower()
+                target_filename = NOC_FILE_NAME_MAPPING[source_filename]
+
+                logger.info(
+                    f"Copying s3://{noc_bucket}/{source_key} to s3://{noc_bucket}/{target_filename}"
+                )
+                s3_client.copy_object(
+                    Bucket=noc_bucket,
+                    CopySource={"Bucket": noc_bucket, "Key": source_key},
+                    Key=target_filename,
+                )
+                noc_s3_keys.append(target_filename)
+            bucket = noc_bucket
+
+        # Process each selected CSV
+        for noc_s3_key in noc_s3_keys:
+            logger.info(f"Running scheduled NOC upload from bucket: {bucket} for file: {noc_s3_key}")
+            insert_in_database(noc_s3_key, bucket, noc_bucket_region=noc_bucket_region)
 
     except Exception as e:
         ssm.put_parameter(

--- a/repos/fdbt-reference-data-service/src/retrievers/serverless.yml
+++ b/repos/fdbt-reference-data-service/src/retrievers/serverless.yml
@@ -17,6 +17,11 @@ provider:
     NPTG_S3_KEY: ${env:NPTG_S3_KEY, ''}
     NPTG_BUCKET_NAME: ${env:NPTG_BUCKET_NAME, ''}
     NPTG_ROLE_ARN: ${env:NPTG_ROLE_ARN, ''}
+    NOC_BUCKET_NAME: ${env:NOC_BUCKET_NAME, ''}
+    NOC_S3_KEY: ${env:NOC_S3_KEY, ''}
+    NOC_TMP_PATH: ${env:NOC_TMP_PATH, ''}
+    NOC_ROLE_ARN: ${env:NOC_ROLE_ARN, ''}
+    NOC_BUCKET_REGION: ${env:NOC_BUCKET_REGION, ''}
   iam:
     role:
       statements:
@@ -33,6 +38,7 @@ provider:
             - !Sub arn:aws:s3:::fdbt-csv-ref-data-${self:provider.stage}/*
             - !Sub arn:aws:s3:::fdbt-txc-ref-data-${self:provider.stage}/*
             - !Sub arn:aws:s3:::fdbt-txc-ref-data-zipped-${self:provider.stage}/*
+            - !Sub arn:aws:s3:::fdbt-noc-ref-data-${self:provider.stage}/*
         - Effect: "Allow"
           Action:
             - "cloudwatch:PutMetricData"
@@ -109,13 +115,9 @@ custom:
 
 functions:
   NocRetriever:
-    handler: csv_retriever/main.lambda_handler
+    handler: csv_retriever/main.noc_handler
     timeout: 60
     memorySize: 256
-    environment:
-      DATA_URL: https://www.travelinedata.org.uk/wp-content/themes/desktop/nocadvanced_download.php?reportFormat=csvFlatFile&allTable%5B%5D=table_noclines&allTable%5B%5D=table_noc_table&allTable%5B%5D=table_public_name&submit=Submit
-      BUCKET_NAME: fdbt-csv-ref-data-${self:provider.stage}
-      CONTENT_TYPE: text/csv
     events:
       - schedule:
           rate: cron(0 2 * * ? *)


### PR DESCRIPTION
Updating NOC Code reference to call S3 bucket from BODS instead of calling directly from the API
Updates to the following files:

- repos/fdbt-reference-data-service/src/retrievers/csv_retriever/main.py
- repos/fdbt-reference-data-service/src/retrievers/serverless.yml

This PR is following the revert of the last create data PR https://github.com/department-for-transport-BODS/bods-transport-data-parser/pull/359 which was reverted due to the catch of a recursive loop that was implemented by mistake

